### PR TITLE
[FIX] Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set current repository and branch
         run: |
-          echo "DOTLY_REPOSITORY=${DOTLY_PR_REPOSITORY:-CodelyTV/dotly}" >> $GITHUB_ENV
+          echo "DOTLY_REPOSITORY=${DOTLY_PR_REPOSITORY:-gtrabanco/sloth}" >> $GITHUB_ENV
           echo "DOTLY_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
           echo "DOTLY_ENV=CI" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,9 @@ jobs:
         run: go get mvdan.cc/sh/v3/cmd/shfmt
 
       - name: 💅 Lint bash files and apply linting patches
-        run: bash scripts/self/lint --patch
+        run: |
+          bash scripts/self/lint || {
+            . "scripts/core/_main.sh"
+            output::write "Apply patches by using \`lazy self lint\`"
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - macos-10.15
-          - macos-11.0
+          - macos-11
           - ubuntu-18.04
           - ubuntu-20.04
 
@@ -69,5 +69,5 @@ jobs:
       - name: 📥 Install shfmt
         run: go get mvdan.cc/sh/v3/cmd/shfmt
 
-      - name: 💅 Lint bash files
-        run: bash scripts/self/lint
+      - name: 💅 Lint bash files and apply linting patches
+        run: bash scripts/self/lint --patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os:
           - macos-10.15
-          - macos-11
           - ubuntu-18.04
           - ubuntu-20.04
 


### PR DESCRIPTION
Fix linter output information
Removed macOS 11 from the matrix of checks because is only supported as preview. More information about this:
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
- https://github.com/actions/virtual-environments/blob/main/docs/macos-11-onboarding.md (to ask permission to access macOS 11 runner)