### PR TITLE
[Fix] Script creation and install

### DIFF
--- a/scripts/script/create
+++ b/scripts/script/create
@@ -8,9 +8,9 @@ set -euo pipefail
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
 dot::load_library "templating.sh"
 
-is_invalid_name() {
+is_valid_name() {
   local -r name="${1:-}"
-  ! [[ "$name" =~ ^_ || "$name" == .* ]]
+  ! [[ "${name:0:1}" == "_" || "${name:0:1}" == "." ]]
 }
 
 ##? Dotly script creator
@@ -58,7 +58,7 @@ case "${1:-}" in
     exit 1
   fi
 
-  if is_invalid_name "$name"; then
+  if is_valid_name "$name"; then
     output::error "The given name \`$name\` for binary is wrong. Names can not start with \`.\` or \`_\`."
     output::answer "These names are restricted for private and non execution or private usage files that should be created manually."
     exit 1
@@ -100,13 +100,13 @@ case "${1:-}" in
     exit 1
   fi
 
-  if is_invalid_name "$context"; then
+  if ! is_valid_name "$context"; then
     output::error "The given name \`$context\` for context is wrong. Names can not start with \`.\` or \`_\`."
     output::answer "These names are restricted for private and non execution or private usage files that should be created manually."
     exit 1
   fi
 
-  if is_invalid_name "$script_name"; then
+  if ! is_valid_name "$script_name"; then
     output::error "The given name \`$script_name\` for script is wrong. Names can not start with \`.\` or \`_\`."
     output::answer "These names are restricted for private and non execution or private usage files that should be created manually."
     exit 1

--- a/scripts/script/install_remote
+++ b/scripts/script/install_remote
@@ -13,9 +13,9 @@ set -euo pipefail
 ##? omited and renamed in your $DOTFILES_PATH/scripts/<context> folder
 ##?
 ##? Usage:
-##?   install-remote [ -h | --help ]
-##?   install-remote [ -v | --version ]
-##?   install-remote <context> <script_raw_url> [<script_name>]
+##?   install_remote [ -h | --help ]
+##?   install_remote [ -v | --version ]
+##?   install_remote <context> <script_raw_url> [<script_name>]
 ##?
 ##? Options:
 ##?   -h --help     Show this help
@@ -26,7 +26,7 @@ set -euo pipefail
 ##?   Gabriel Trabanco Llano <gtrabanco@users.noreply.github.com>
 docs::parse "$@"
 
-SCRIPT_NAME="sloth dotly install-remote"
+SCRIPT_NAME="sloth script install_remote"
 SCRIPT_VERSION="1.0.0"
 
 # Print name and version


### PR DESCRIPTION
Fix script creation check of names
Changed `install-remote` to `install_remote`
