### PR TITLE
[Fix] dot script create description

### DIFF
--- a/scripts/script/create
+++ b/scripts/script/create
@@ -156,7 +156,7 @@ case "${1:-}" in
     description="${script_description[*]:-}"
 
     # Description can not be empty
-    [[ -z "$description" ]] && output::question "Description can not be empty, describe your script" "description"
+    [[ -z "$description" ]] && description="$(output::question "Description can not be empty, describe your script")"
 
     cp "${SCRIPT_TEMPLATE_PATH}" "$script_filepath"
     templating::replace "$script_filepath" --script-name="$script_name" --script-context="$context" --script-author="$author" --script-author-email="$email" --script-description="$description" > /dev/null


### PR DESCRIPTION
* Fix script description when using `dot script create` not right captured from new way of using `output::question` and then not writing it correctly to the generated script.

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
