### PR TITLE
[Fix] script::depends_on

### DIFF
--- a/scripts/core/install
+++ b/scripts/core/install
@@ -46,7 +46,7 @@ if platform::command_exists zsh; then
   zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
 fi
 
-if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && [[ "$SHELL" =~ zsh$ ]]; then
+if [[ "${DOTLY_ENV:-PROD}" != "CI" && "$SHELL" =~ zsh$ ]]; then
   output::answer "Installing completions"
   {
     zsh "$DOTLY_PATH/bin/dot" shell zsh reload_completions &> /dev/null &&

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -36,7 +36,7 @@ output::answer "Setting up symlinks"
 "$DOTLY_PATH/bin/dot" symlinks apply | log::file "Applying symlinks" || true
 touch "$HOME/.z"
 
-if ! str::contains zsh "$SHELL"; then
+if ! str::contains zsh "$SHELL" && platform::command_exists chsh && platform::command_exists zsh; then
   output::answer "Setting zsh as the default shell"
   sudo chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
 fi

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -12,6 +12,9 @@ export PATH="$HOME/.cargo/bin:$PATH"
 if platform::is_macos; then
   output::answer "🍎 Setting up macOS platform"
   install_macos_custom
+elif platform::is_linux; then
+  output::answer "🐧 Setting up Linux Platform"
+  install_linux_custom
 fi
 
 script::depends_on docpars fzf zsh python

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -41,8 +41,10 @@ if ! str::contains zsh "$SHELL"; then
   sudo chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
 fi
 
-output::answer "Installing zim"
-zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
+if platform::command_exists zsh; then
+  output::answer "Installing zim"
+  zsh "$ZIM_HOME/zimfw.zsh" install | log::file "Installing zim"
+fi
 
 if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && [[ "$SHELL" =~ zsh$ ]]; then
   output::answer "Installing completions"

--- a/scripts/core/src/_main.sh
+++ b/scripts/core/src/_main.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 if ! ${DOT_MAIN_SOURCED:-false}; then
-  for file in "${SLOTH_PATH:-$DOTLY_PATH}"/scripts/core/src/{args,array,async,collections,documentation,dot,files,git,log,platform,output,registry,script,str}.sh; do
+  # platform and output should be at the first place because they are used
+  # in other libraries
+  for file in "${SLOTH_PATH:-$DOTLY_PATH}"/scripts/core/src/{platform,output,args,array,async,collections,documentation,dot,files,git,log,package,registry,script,str}.sh; do
     #shellcheck source=/dev/null
     . "$file" || exit 5
   done

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -45,7 +45,7 @@ install_macos_custom() {
 
   # To make CI Checks faster this packages are only installed in production
   if [[ "${DOTLY_ENV:-PROD}" == "PROD" ]]; then
-    brew::install gnutls gnu-tar gnu-which gawk grep make bat hyperfine
+    brew::install gnutls gnu-tar gnu-which gawk grep make hyperfine
   fi
 
   output::answer "Installing mas"
@@ -53,5 +53,19 @@ install_macos_custom() {
 }
 
 install_linux_custom() {
-  echo
+  linux::install() {
+    if [[ $# -eq 0 ]]; then
+      return
+    fi
+
+    package::is_installed "$1" || package::install "$1" | log::file "Installing $1"
+    shift
+
+    if [[ $# -gt 0 ]]; then
+      "$0" "$@"
+    fi
+  }
+
+  output::answer "Installing needed packages"
+  linux::install bash zsh hyperfine
 }

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -8,7 +8,7 @@ install_macos_custom() {
       "$0" "${@:2}"
     fi
 
-    brew list "$1" 2>/dev/null || brew install "$1" | log::file "Installing brew $1"
+    brew list "$1" 2> /dev/null || brew install "$1" | log::file "Installing brew $1"
   }
 
   if ! platform::command_exists brew; then

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -53,6 +53,7 @@ install_macos_custom() {
 }
 
 install_linux_custom() {
+  local -r package_manager="$(package::preferred_manager)"
   linux::install() {
     if [[ $# -eq 0 ]]; then
       return
@@ -65,6 +66,11 @@ install_linux_custom() {
       "$0" "$@"
     fi
   }
+
+  # To make CI Cheks faster avoid package manager update & upgrade
+  if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+    package::command_exists "$package_manager" self_update && package::command "$package_manager" self_update
+  fi
 
   output::answer "Installing needed packages"
   linux::install bash zsh hyperfine

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -4,11 +4,14 @@ install_macos_custom() {
   brew::install() {
     if [[ $# -eq 0 ]]; then
       return
-    elif [[ $# -gt 1 ]]; then
-      "$0" "${@:2}"
     fi
 
     brew list "$1" 2> /dev/null || brew install "$1" | log::file "Installing brew $1"
+    shift
+
+    if [[ $# -gt 0 ]]; then
+      "$0" "$@"
+    fi
   }
 
   if ! platform::command_exists brew; then

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -53,7 +53,7 @@ install_macos_custom() {
 }
 
 install_linux_custom() {
-  local -r package_manager="$(package::preferred_manager)"
+  local -r package_manager="$(package::manager_preferred)"
   linux::install() {
     if [[ $# -eq 0 ]]; then
       return

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -10,7 +10,7 @@ install_macos_custom() {
     shift
 
     if [[ $# -gt 0 ]]; then
-      "$0" "$@"
+      brew::install "$@"
     fi
   }
 
@@ -63,7 +63,7 @@ install_linux_custom() {
     shift
 
     if [[ $# -gt 0 ]]; then
-      "$0" "$@"
+      linux::install "$@"
     fi
   }
 

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -26,6 +26,7 @@ install_macos_custom() {
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
     brew update --force | log::file "Brew update"
     brew upgrade --force | log::file "Brew upgrade current packages"
+    brew list gnutls || brew install gnutls | log::file "Installing brew gnutls"
   fi
   brew list bash || brew install bash | log::file "Installing brew bash"
   brew list zsh || brew install zsh | log::file "Installing brew zsh"
@@ -34,7 +35,6 @@ install_macos_custom() {
   brew list gnu-tar || brew install gnu-tar | log::file "Installing brew gnu-tar"
   brew list gnu-sed || brew install gnu-sed | log::file "Installing brew gnu-sed"
   brew list gawk || brew install gawk | log::file "Installing brew gawk"
-  brew list gnutls || brew install gnutls | log::file "Installing brew gnutls"
   brew list gnu-which || brew install gnu-which | log::file "Installing brew gnu-which"
   brew list grep || brew install grep | log::file "Installing brew grep"
   brew list make || brew install make | log::file "Installing brew make"

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -1,6 +1,16 @@
 #!/bin/user/env bash
 
 install_macos_custom() {
+  brew::install() {
+    if [[ $# -eq 0 ]]; then
+      return
+    elif [[ $# -gt 1 ]]; then
+      "$0" "${@:2}"
+    fi
+
+    brew list "$1" 2>/dev/null || brew install "$1" | log::file "Installing brew $1"
+  }
+
   if ! platform::command_exists brew; then
     output::error "brew not installed, installing"
 
@@ -22,27 +32,21 @@ install_macos_custom() {
   output::answer "Installing needed gnu packages"
   brew cleanup -s | log::file "Brew executing cleanup"
   brew cleanup --prune-prefix | log::file "Brew removeing dead symlinks"
-  # In CI we want to do it all faster so we avoid update & upgrade and some packages
+  # To make CI Cheks faster avoid brew update & upgrade
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
     brew update --force | log::file "Brew update"
     brew upgrade --force | log::file "Brew upgrade current packages"
-    brew list gnutls || brew install gnutls | log::file "Installing brew gnutls"
-    brew list gnu-tar || brew install gnu-tar | log::file "Installing brew gnu-tar"
-    brew list bat || brew install bat | log::file "Installing brew bat"
-    brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
-    brew list gnu-which || brew install gnu-which | log::file "Installing brew gnu-which"
   fi
-  brew list bash || brew install bash | log::file "Installing brew bash"
-  brew list zsh || brew install zsh | log::file "Installing brew zsh"
-  brew list coreutils || brew install coreutils | log::file "Installing brew coreutils"
-  brew list findutils || brew install findutils | log::file "Installing brew findutils"
-  brew list gnu-sed || brew install gnu-sed | log::file "Installing brew gnu-sed"
-  brew list gawk || brew install gawk | log::file "Installing brew gawk"
-  brew list grep || brew install grep | log::file "Installing brew grep"
-  brew list make || brew install make | log::file "Installing brew make"
+
+  brew::install bash zsh coreutils findutils gnu-sed
+
+  # To make CI Checks faster this packages are only installed in production
+  if [[ "${DOTLY_ENV:-PROD}" == "PROD" ]]; then
+    brew::install gnutls gnu-tar gnu-which gawk grep make bat hyperfine
+  fi
 
   output::answer "Installing mas"
-  brew list mas || brew install mas | log::file "Installing mas"
+  brew::install mas
 }
 
 install_linux_custom() {

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -22,24 +22,24 @@ install_macos_custom() {
   output::answer "Installing needed gnu packages"
   brew cleanup -s | log::file "Brew executing cleanup"
   brew cleanup --prune-prefix | log::file "Brew removeing dead symlinks"
-  # In CI we want to do it all faster so we avoid update & upgrade
+  # In CI we want to do it all faster so we avoid update & upgrade and some packages
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
     brew update --force | log::file "Brew update"
     brew upgrade --force | log::file "Brew upgrade current packages"
     brew list gnutls || brew install gnutls | log::file "Installing brew gnutls"
+    brew list gnu-tar || brew install gnu-tar | log::file "Installing brew gnu-tar"
+    brew list bat || brew install bat | log::file "Installing brew bat"
+    brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
+    brew list gnu-which || brew install gnu-which | log::file "Installing brew gnu-which"
   fi
   brew list bash || brew install bash | log::file "Installing brew bash"
   brew list zsh || brew install zsh | log::file "Installing brew zsh"
   brew list coreutils || brew install coreutils | log::file "Installing brew coreutils"
   brew list findutils || brew install findutils | log::file "Installing brew findutils"
-  brew list gnu-tar || brew install gnu-tar | log::file "Installing brew gnu-tar"
   brew list gnu-sed || brew install gnu-sed | log::file "Installing brew gnu-sed"
   brew list gawk || brew install gawk | log::file "Installing brew gawk"
-  brew list gnu-which || brew install gnu-which | log::file "Installing brew gnu-which"
   brew list grep || brew install grep | log::file "Installing brew grep"
   brew list make || brew install make | log::file "Installing brew make"
-  brew list bat || brew install bat | log::file "Installing brew bat"
-  brew list hyperfine || brew install hyperfine | log::file "Installing brew hyperfine"
 
   output::answer "Installing mas"
   brew list mas || brew install mas | log::file "Installing mas"

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 export PACKAGE_MANAGERS_SRC=(
   "${SLOTH_PATH:-$DOTLY_PATH}/scripts/package/src/package_managers"
-  "${DOTFILES_PATH}/package_managers"
+  "${DOTFILES_PATH:-}/package_managers"
   "${PACKAGE_MANAGERS_SRC[@]:-}"
 )
 

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -144,7 +144,7 @@ package::_install() {
   return 1
 }
 
-package::preferred_manager() {
+package::manager_preferred() {
   local all_available_pkgmgrs
 
   mapfile -t all_available_pkgmgrs < <(package::get_available_package_managers)

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -2,7 +2,7 @@
 export PACKAGE_MANAGERS_SRC=(
   "${SLOTH_PATH:-$DOTLY_PATH}/scripts/package/src/package_managers"
   "${DOTFILES_PATH}/package_managers"
-  "${PACKAGE_MANAGERS_SRC[@]}"
+  "${PACKAGE_MANAGERS_SRC[@]:-}"
 )
 
 if [[ -z "${SLOTH_PACKAGE_MANAGERS_PRECEDENCE:-}" ]]; then

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -144,6 +144,17 @@ package::_install() {
   return 1
 }
 
+package::preferred_manager() {
+  local all_available_pkgmgrs
+
+  mapfile -t all_available_pkgmgrs < <(package::get_available_package_managers)
+  eval "$(array::uniq_unordered "${SLOTH_PACKAGE_MANAGERS_PRECEDENCE[@]}" "${all_available_pkgmgrs[@]}")"
+
+  if [[ ${#uniq_values[@]} -gt 0 ]]; then
+    echo "${uniq_values[0]}"
+  fi
+}
+
 # Try to install with any package manager
 package::install() {
   local all_available_pkgmgrs uniq_values package_manager package

--- a/scripts/core/src/script.sh
+++ b/scripts/core/src/script.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 command_or_package_exists() {
-  platform::command_exists "$1" || registry::is_installed "$1"
+  platform::command_exists "$1" ||
+  package::is_installed "$1" ||
+  registry::is_installed "$1"
 }
 
 script::depends_on() {

--- a/scripts/core/src/script.sh
+++ b/scripts/core/src/script.sh
@@ -2,8 +2,8 @@
 
 command_or_package_exists() {
   platform::command_exists "$1" ||
-  package::is_installed "$1" ||
-  registry::is_installed "$1"
+    package::is_installed "$1" ||
+    registry::is_installed "$1"
 }
 
 script::depends_on() {

--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -13,7 +13,7 @@ dot::load_library "templating.sh" "core"
 ##?
 docs::parse "$@"
 
-DOTFILES_PATH="${2:-$DOTFILES_PATH}"
+DOTFILES_PATH="${2:-${DOTFILES_PATH:-}}"
 
 [[ -z "$DOTFILES_PATH" ]] && output::error "DOTFILES_PATH not found" && exit 1
 

--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -11,7 +11,11 @@ dot::load_library "templating.sh" "core"
 ##? Usage:
 ##?    create [<dotfiles_path>]
 ##?
-docs::parse "$@"
+if ! ${DOTLY_INSTALLER:-false}; then
+  docs::parse "$@"
+elif [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  grep '^##?' "$0" | tr '##? ' ' '
+fi
 
 DOTFILES_PATH="${2:-${DOTFILES_PATH:-}}"
 

--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -4,7 +4,7 @@ set -euo pipefail
 
 #shellcheck disable=SC1091
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "templating.sh"
+dot::load_library "templating.sh" "core"
 
 ##? Create the dotfiles structure
 ##?

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -2,7 +2,6 @@
 
 #shellcheck disable=SC1091
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "package.sh"
 
 ##? Install a package
 ##?

--- a/scripts/package/brew
+++ b/scripts/package/brew
@@ -2,7 +2,6 @@
 
 #shellcheck disable=1091
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "package.sh"
 #shellcheck disable=SC2034
 FORCED_PKGMGR="brew"
 

--- a/scripts/package/check
+++ b/scripts/package/check
@@ -6,7 +6,6 @@ set -euo pipefail
 
 #shellcheck disable=SC1091
 . "${DOTLY_PATH:-$SLOTH_PATH}/scripts/core/_main.sh"
-dot::load_library "package.sh"
 
 ##? Install a package
 ##?

--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -2,7 +2,6 @@
 
 #shellcheck disable=SC1091
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "package.sh"
 dot::load_library "dump.sh"
 
 if platform::command_exists npm; then

--- a/scripts/package/import
+++ b/scripts/package/import
@@ -2,7 +2,6 @@
 
 #shellcheck disable=SC1091
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "package.sh"
 dot::load_library "dump.sh"
 
 ##? Import previously dumped packages from:

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 . "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-dot::load_library "package.sh"
 
 update_all_error() {
   [[ -n "${1:-}" ]] && output::write "Error updating ${1:-} apps. See \`dot self debug\` for view errors"


### PR DESCRIPTION
* `package.sh` now it is a core library because it is used in `script.sh` library.
* `platform.sh` and `output.sh` moved to the very beginning of loading because these libraries can be very used in other libraries (also called as Libraries Minority Report Inception fix).
