### PR TITLE
[Fix] _output::parse_code to reset style after outputting

### DIFF
--- a/scripts/core/src/output.sh
+++ b/scripts/core/src/output.sh
@@ -8,7 +8,7 @@ normal='\033[0m'
 _output::parse_code() {
   local normal="\033[0m" style="$normal"
   case "${1:-}" in
-    --color|--style)
+    --color | --style)
       style="$2"
       shift 2
       ;;

--- a/scripts/core/src/output.sh
+++ b/scripts/core/src/output.sh
@@ -6,19 +6,19 @@ bold_blue='\033[1m\033[34m'
 normal='\033[0m'
 
 _output::parse_code() {
-  local color="$normal"
+  local normal="\033[0m" style="$normal"
   case "${1:-}" in
-    --color)
-      color="$2"
+    --color|--style)
+      style="$2"
       shift 2
       ;;
   esac
 
   local -r text="${*:-}"
 
-  with_code_parsed=$(echo "$text" | awk "{ORS=(NR+1)%2==0?\"${green}\":RS}1" RS="\`" | awk "{ORS=NR%1==0?\"${color}\":RS}1" RS="\`" | tr -d '\n')
+  with_code_parsed=$(echo "$text" | awk "{ORS=(NR+1)%2==0?\"${green}\":RS}1" RS="\`" | awk "{ORS=NR%1==0?\"${style}\":RS}1" RS="\`" | tr -d '\n')
 
-  echo -e "$with_code_parsed"
+  echo -e "${with_code_parsed}${normal}"
 }
 
 output::write() {


### PR DESCRIPTION
<!---
Please use English as main language
Provide a general summary of your changes in the Title above
Use prefix by type of change:
- [Feature]
- [Fix]
- [Doc]
Also add [HELP NEEDED] before if you need some∩ help.
Add also [WIP] before every other prefix if you have task to do or you have proposed task (because work in a team or you desire some help).
-->

## Description
Fixes formatting error in `_output::parse_code` that were not reseting the style/color after print the output. This caused to print in a wrong color when the style is different than normal.

For example after using `output::error` if you were using next `output::write` the output was red instead the normal color.