### PR TITLE
[FIX] Added error message in initialiser for vars

### DIFF
--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -23,6 +23,21 @@ function recent_dirs() {
   cd "$(echo "$selected" | sed "s/\~/$escaped_home/")" || echo "Invalid directory"
 }
 
+# Advise no vars defines
+if [[ -z "${DOTFILES_PATH:-}" || ! -d "${DOTFILES_PATH:-}" || -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]]; then
+  if [[ -d "$HOME/.dotfiles" && -d "$HOME/.dotfiles/modules/dotly" ]]; then
+    DOTFILES_PATH="$HOME/.dotfiles"
+    SLOTH_PATH="$DOTFILES_PATH/modules/dotly"
+    DOTLY_PATH="$SLOTH_PATH"
+  elif [[ -d "$HOME/.dotfiles" && -d "$HOME/.dotfiles/modules/sloth" ]]; then
+    DOTFILES_PATH="$HOME/.dotfiles"
+    SLOTH_PATH="$DOTFILES_PATH/modules/sloth"
+    DOTLY_PATH="$SLOTH_PATH"
+  else
+    echo -e "\033[0;31m\033[1mDOTFILES_PATH or SLOTH_PATH is not defined or is wrong, .Sloth will fail\033[0m"
+  fi
+fi
+
 # Envs
 # GPG TTY
 GPG_TTY="$(tty)"


### PR DESCRIPTION
<!---
Please use English as main language
Provide a general summary of your changes in the Title above
Use prefix by type of change:
- [Feature]
- [Fix]
- [Doc]
Also add [HELP NEEDED] before if you need some∩ help.
Add also [WIP] before every other prefix if you have task to do or you have proposed task (because work in a team or you desire some help).
-->

## Description
<!--- Describe your changes -->
Added feedback on loader if .Sloth is trying to start but `DOTFILES_PATH` or `SLOTH_PATH` or `DOTLY_PATH` are not right defined.

By default if any of these vars fail it will try to locate your dotfiles in `$HOME/.dotfiles` and sloth or dotly in `$HOME/.dotfiles/modules/{dotly,sloth}`.

## Related Issue
<!--- If suggesting a new feature or change and was discussed it firs. Add here the link to the issue or discussion. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Possible errors loading .Sloth if any of these variables are wrong

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide feedback to the user if any of these vars are wrong and the dotfiles or .Sloth could not be located in the default directory