### PR TITLE
[Fix] platform::is_linux

### DIFF
--- a/scripts/core/src/platform.sh
+++ b/scripts/core/src/platform.sh
@@ -29,20 +29,20 @@ platform::macos_version_name() {
   ! platform::is_macos && return
 
   case "$(platform::macos_version)" in
-      "10.4"*) version_name="Mac OS X Tiger" ;;
-      "10.5"*) version_name="Mac OS X Leopard" ;;
-      "10.6"*) version_name="Mac OS X Snow Leopard" ;;
-      "10.7"*) version_name="Mac OS X Lion" ;;
-      "10.8"*) version_name="OS X Mountain Lion" ;;
-      "10.9"*) version_name="OS X Mavericks" ;;
-      "10.10"*) version_name="OS X Yosemite" ;;
-      "10.11"*) version_name="OS X El Capitan" ;;
-      "10.12"*) version_name="macOS Sierra" ;;
-      "10.13"*) version_name="macOS High Sierra" ;;
-      "10.14"*) version_name="macOS Mojave" ;;
-      "10.15"*) version_name="macOS Catalina" ;;
-      "11"*) version_name="macOS Big Sur" ;;
-      "12"*) version_name="macOS Monterey" ;;
+    "10.4"*) version_name="Mac OS X Tiger" ;;
+    "10.5"*) version_name="Mac OS X Leopard" ;;
+    "10.6"*) version_name="Mac OS X Snow Leopard" ;;
+    "10.7"*) version_name="Mac OS X Lion" ;;
+    "10.8"*) version_name="OS X Mountain Lion" ;;
+    "10.9"*) version_name="OS X Mavericks" ;;
+    "10.10"*) version_name="OS X Yosemite" ;;
+    "10.11"*) version_name="OS X El Capitan" ;;
+    "10.12"*) version_name="macOS Sierra" ;;
+    "10.13"*) version_name="macOS High Sierra" ;;
+    "10.14"*) version_name="macOS Mojave" ;;
+    "10.15"*) version_name="macOS Catalina" ;;
+    "11"*) version_name="macOS Big Sur" ;;
+    "12"*) version_name="macOS Monterey" ;;
   esac
 
   echo "$version_name"
@@ -104,7 +104,7 @@ platform::os() {
     darwin*)
       os="macos"
       ;;
-    linux|gnu)
+    linux | gnu)
       if platform::is_wsl; then
         os="wsl"
       else

--- a/scripts/core/src/platform.sh
+++ b/scripts/core/src/platform.sh
@@ -1,16 +1,60 @@
 #!/usr/bin/env bash
 
+#
+# If you need more system information, consider to add neofetch as submodule
+#   https://github.com/dylanaraps/neofetch
+#
+
+#shellcheck disable=SC2034,SC2207
+DOTLY_UNAME=($(uname -sm))
+if [[ -n "${DOTLY_UNAME[0]:-}" ]]; then
+  DOTLY_OS="$(echo "${DOTLY_UNAME[0]}" | tr '[:upper:]' '[:lower:]')"
+  DOTLY_ARCH="${DOTLY_UNAME[1]}"
+else
+  DOTLY_OS="$(echo "${DOTLY_UNAME[1]}" | tr '[:upper:]' '[:lower:]')"
+  DOTLY_ARCH="${DOTLY_UNAME[2]}"
+fi
+
 platform::command_exists() {
   type "$1" > /dev/null 2>&1
 }
 
+platform::macos_version() {
+  { platform::is_macos && sw_vers -productVersion; } || return
+}
+
+platform::macos_version_name() {
+  local version_name="macOS"
+
+  ! platform::is_macos && return
+
+  case "$(platform::macos_version)" in
+      "10.4"*) version_name="Mac OS X Tiger" ;;
+      "10.5"*) version_name="Mac OS X Leopard" ;;
+      "10.6"*) version_name="Mac OS X Snow Leopard" ;;
+      "10.7"*) version_name="Mac OS X Lion" ;;
+      "10.8"*) version_name="OS X Mountain Lion" ;;
+      "10.9"*) version_name="OS X Mavericks" ;;
+      "10.10"*) version_name="OS X Yosemite" ;;
+      "10.11"*) version_name="OS X El Capitan" ;;
+      "10.12"*) version_name="macOS Sierra" ;;
+      "10.13"*) version_name="macOS High Sierra" ;;
+      "10.14"*) version_name="macOS Mojave" ;;
+      "10.15"*) version_name="macOS Catalina" ;;
+      "11"*) version_name="macOS Big Sur" ;;
+      "12"*) version_name="macOS Monterey" ;;
+  esac
+
+  echo "$version_name"
+}
+
 platform::get_os() {
-  echo "$OSTYPE" | tr '[:upper:]' '[:lower:]'
+  echo "$DOTLY_OS" | tr '[:upper:]' '[:lower:]'
 }
 
 platform::get_arch() {
-  local architecture=""
-  case $(uname -m) in
+  local architecture="unknown"
+  case "$DOTLY_ARCH" in
     x86_64)
       architecture="amd64"
       ;;
@@ -33,7 +77,7 @@ platform::is_arm() {
 }
 
 platform::is_macos() {
-  [[ $(platform::get_os) == "darwin"* ]]
+  [[ $DOTLY_OS == "darwin"* ]]
 }
 
 platform::is_macos_arm() {
@@ -41,29 +85,39 @@ platform::is_macos_arm() {
 }
 
 platform::is_linux() {
-  [[ $(platform::get_os) == *"linux"* ]]
+  [[ $DOTLY_OS == *"linux"* ]]
 }
 
 platform::is_wsl() {
-  grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null
+  grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null || grep -q -F 'Microsoft' /proc/sys/kernel/osrelease
 }
 
 platform::is_bsd() {
-  platform::is_macos || [[ $(platform::get_os) == *"bsd"* ]]
+  [[ $DOTLY_OS == *"bsd"* ]]
 }
 
 platform::os() {
+  # Should never show unknown but expect the unexpected ;)
   local os="unknown"
 
-  if platform::is_macos; then
-    os="mac"
-  elif platform::is_linux; then
-    os="linux"
-  elif platform::is_bsd && ! platform::is_macos; then
-    os="bsd"
-  elif platform::is_wsl; then
-    os="wsl-linux"
-  fi
+  case "$DOTLY_OS" in
+    darwin*)
+      os="macos"
+      ;;
+    linux|gnu)
+      if platform::is_wsl; then
+        os="wsl"
+      else
+        os="linux"
+      fi
+      ;;
+    *bsd*)
+      os="bsd"
+      ;;
+    *)
+      os="$DOTLY_OS"
+      ;;
+  esac
 
   echo "$os"
 }


### PR DESCRIPTION
* Improve calling uname to be once in core library `platform.sh`
* Added `platfor::macos_version` in core library `platform.sh`
* Added `platform::macos_version_name` in core library `platform.sh`
* Fixed `platform::is_linux` in core library `platform.sh`