### PR TITLE
Try to fix zsh installation when zsh is not installed

### DIFF
--- a/scripts/core/install
+++ b/scripts/core/install
@@ -60,11 +60,11 @@ touch "$HOME/.z"
 unset symlinks_args bk
 
 # ZSH as default shell if we are using zsh
-output::answer "Setting zsh as the default shell"
-if ! str::contains zsh "$SHELL" && platform::command_exists chsh; then
+if ! str::contains zsh "$SHELL" && platform::command_exists chsh && platform::command_exists zsh; then
+  output::answer "Setting zsh as the default shell"
   sudo chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
 else
-  output::error "ZSH could not be setup as default shell"
+  output::error "ZSH is not installed?"
 fi
 
 # If exists zsh install ZIMFW

--- a/scripts/core/src/str.sh
+++ b/scripts/core/src/str.sh
@@ -8,7 +8,7 @@ str::split() {
 }
 
 str::contains() {
-  [[ $2 == *$1* ]]
+  [[ $2 == *"$1"* ]]
 }
 
 str::to_upper() { echo "${@:-$(< /dev/stdin)}" | tr '[:lower:]' '[:upper:]'; }


### PR DESCRIPTION
* Fix try to set up zsh as default shell only if zsh exists on `dot core install`
* Added right part of `str::contains` between `"` double quotes.