### PR TITLE
[Fix] Fitting loader and zsh script

### DIFF
--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -13,12 +13,14 @@
 ##?   zsh fix_permissions
 ##?
 ##? Arguments:
-##?   optimize             
-##?   test_performance     Check how much time is the loading of zsh shell 
-##?   reload_completions   
-##?   clean_cache          
+##?   optimize
+##?   test_performance     Check how much time is the loading of zsh shell
+##?   reload_completions
+##?   clean_cache
 ##?   fix_permissions      Fix error: "zsh compinit: insecure directories"
 ##?
+##?
+##? SCRIPT_VERSION "2.1.0"
 docs::parse "$@"
 
 case $1 in
@@ -60,7 +62,7 @@ case $1 in
     output::answer 'Now restart your terminal'
     ;;
   "fix_permissions")
-    if [[ -z "${HOMEBREW_PREFIX:-}" ]] && command -v brew &>/dev/null; then
+    if [[ -z "${HOMEBREW_PREFIX:-}" ]] && command -v brew &> /dev/null; then
       HOMEBREW_PREFIX="$(brew --prefix)"
     elif [[ -d "/usr/local/share/zsh" ]]; then
       HOMEBREW_PREFIX="/usr/local"

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -60,6 +60,16 @@ case $1 in
     output::answer 'Now restart your terminal'
     ;;
   "fix_permissions")
+    if [[ -z "${HOMEBREW_PREFIX:-}" ]] && command -v brew &>/dev/null; then
+      HOMEBREW_PREFIX="$(brew --prefix)"
+      chmod -R go-w "${HOMEBREW_PREFIX}/share/zsh"
+    elif [[ -d "/usr/local/share/zsh" ]]; then
+      HOMEBREW_PREFIX="/usr/local"
+    else
+      output::error "Brew not detected if you want to fix any other insecure path use \`chmod -R go-w <your_path>\`"
+      exit 1
+    fi
+
     chmod -R go-w "${HOMEBREW_PREFIX}/share/zsh"
     ;;
   *)

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -62,7 +62,6 @@ case $1 in
   "fix_permissions")
     if [[ -z "${HOMEBREW_PREFIX:-}" ]] && command -v brew &>/dev/null; then
       HOMEBREW_PREFIX="$(brew --prefix)"
-      chmod -R go-w "${HOMEBREW_PREFIX}/share/zsh"
     elif [[ -d "/usr/local/share/zsh" ]]; then
       HOMEBREW_PREFIX="/usr/local"
     else

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -11,6 +11,14 @@
 ##?   zsh reload_completions
 ##?   zsh clean_cache
 ##?   zsh fix_permissions
+##?
+##? Arguments:
+##?   optimize             
+##?   test_performance     Check how much time is the loading of zsh shell 
+##?   reload_completions   
+##?   clean_cache          
+##?   fix_permissions      Fix error: "zsh compinit: insecure directories"
+##?
 docs::parse "$@"
 
 case $1 in
@@ -52,9 +60,7 @@ case $1 in
     output::answer 'Now restart your terminal'
     ;;
   "fix_permissions")
-    sudo -v
-    sudo chown -R "$(whoami)" /usr/local/share/zsh /usr/local/share/zsh/site-functions
-    chmod u+w /usr/local/share/zsh /usr/local/share/zsh/site-functions
+    chmod -R go-w "${HOMEBREW_PREFIX}/share/zsh"
     ;;
   *)
     exit 1

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -45,6 +45,7 @@ case $1 in
     find "$HOME" -name '*.zwc' -delete
     ;;
   "reload_completions")
+    rm -f "$HOME/.zcompdump"
     zsh -i -c "autoload -U compaudit && autoload -Uz compinit && compinit"
 
     output::empty_line

--- a/shell/bash/init.sh
+++ b/shell/bash/init.sh
@@ -22,7 +22,7 @@ themes_paths=(
 )
 
 # brew Bash completion & completions
-if type brew &> /dev/null; then
+if [[ -n "${HOMEBREW_PREFIX:-}" ]]; then
   if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
     #shellcheck source=/dev/null
     . "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
@@ -31,9 +31,9 @@ if type brew &> /dev/null; then
       #shellcheck source=/dev/null
       [[ -r "$COMPLETION" ]] && . "$COMPLETION"
     done
+    unset COMPLETION
   fi
 fi
-unset COMPLETION
 
 #shellcheck disable=SC2068
 for THEME_PATH in ${themes_paths[@]}; do
@@ -42,11 +42,10 @@ for THEME_PATH in ${themes_paths[@]}; do
   #shellcheck source=/dev/null
   [ -f "$THEME_PATH" ] && . "$THEME_PATH" && break
 done
-unset THEME_PATH
 
 find {"$DOTLY_PATH","$DOTFILES_PATH"}"/shell/bash/completions/" -name "_*" -print0 -exec echo {} \; 2> /dev/null | xargs -0 -I _ echo _ | while read -r completion; do
   [[ -z "$completion" ]] && continue
   #shellcheck source=/dev/null
   . "$completion" || echo -e "\033[0;31mBASH completion '$completion' could not be loaded\033[0m"
 done
-unset completion
+unset completion THEME_PATH

--- a/shell/bash/init.sh
+++ b/shell/bash/init.sh
@@ -21,16 +21,8 @@ themes_paths=(
   "$SLOTH_PATH/shell/bash/themes"
 )
 
-# bash completion
-export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
-if [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]]; then
-  #shellcheck source=/dev/null
-  . "/usr/local/etc/profile.d/bash_completion.sh"
-fi
-
-# brew Bash completion
+# brew Bash completion & completions
 if type brew &> /dev/null; then
-  HOMEBREW_PREFIX="$(brew --prefix)"
   if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
     #shellcheck source=/dev/null
     . "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -147,15 +147,17 @@ fi
 unset BREW_BIN user_paths
 
 # Conditional paths
-[[ -f "$HOME/.cargo/env" ]] && path+=("$HOME/.cargo/bin")
+[[ -d "$HOME/.cargo/bin" ]] && path+=("$HOME/.cargo/bin")
 [[ -d "${JAVA_HOME:-}" ]] && path+=("$JAVA_HOME/bin")
 [[ -d "${GEM_HOME:-}" ]] && path+=("$GEM_HOME/bin")
 [[ -d "${GOHOME:-}" ]] && path+=("$GOHOME/bin")
 [[ -d "$HOME/.deno/bin" ]] && path+=("$HOME/.deno/bin")
-[[ -d "/usr/bin" ]] && path+=("/usr/bin")
-[[ -d "/bin" ]] && path+=("/bin")
-[[ -d "/usr/sbin" ]] && path+=("/usr/sbin")
-[[ -d "/sbin" ]] && path+=("/sbin")
+
+# System paths
+path+=("/usr/bin")
+path+=("/bin")
+path+=("/usr/sbin")
+path+=("/sbin")
 
 # Load dotly core for your current BASH
 if [[ -n "$SLOTH_SHELL" && -f "${SLOTH_PATH:-$DOTLY_PATH}/shell/${SLOTH_SHELL}/init.sh" ]]; then

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -145,7 +145,6 @@ else
     "${user_paths[@]}"
   )
 fi
-unset BREW_BIN user_paths
 
 # Conditional paths
 [[ -d "$HOME/.cargo/bin" ]] && path+=("$HOME/.cargo/bin")
@@ -185,4 +184,6 @@ if [[ ${SLOTH_INIT_SCRIPTS:-true} == true ]] && [[ -d "$init_scripts_path" ]]; t
     { [[ -f "$init_script" ]] && . "$init_script"; } || echo -e "\033[0;31m${init_script} could not be loaded\033[0m"
   done
 fi
-unset init_script init_scripts_path
+
+# Unset loader variables
+unset init_script init_scripts_path BREW_BIN user_paths

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -99,6 +99,7 @@ elif command -v brew &> /dev/null; then
   BREW_BIN="$(command -v brew)"
 fi
 
+# Check with -x has no sense because we have done it before :)
 if [[ -n "$BREW_BIN" ]]; then
   HOMEBREW_PREFIX="$("$BREW_BIN" --prefix)"
   HOMEBREW_CELLAR="${HOMEBREW_PREFIX}/Cellar"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -114,16 +114,16 @@ if [[ -n "$BREW_BIN" ]]; then
       "${HOMEBREW_PREFIX}/opt/gnu-which/libexec/gnubin"
       "${HOMEBREW_PREFIX}/opt/grep/libexec/gnubin"
       "${HOMEBREW_PREFIX}/opt/make/libexec/gnubin"
+      "${user_paths[@]}"
       "${HOMEBREW_PREFIX}/bin"
       "${HOMEBREW_PREFIX}/sbin"
-      "${user_paths[@]}"
     )
   else
     # Brew paths
     export path=(
+      "${user_paths[@]}"
       "${HOMEBREW_PREFIX}/bin"
       "${HOMEBREW_PREFIX}/sbin"
-      "${user_paths[@]}"
     )
   fi
 

--- a/shell/zsh/init.sh
+++ b/shell/zsh/init.sh
@@ -26,7 +26,7 @@ setopt +o nomatch
 
 # Start zim
 #shellcheck source=/dev/null
-. "$ZIM_HOME/init.zsh"
+. "${ZIM_HOME}/init.zsh"
 
 # Async mode for autocompletion
 # shellcheck disable=SC2034
@@ -35,10 +35,10 @@ ZSH_AUTOSUGGEST_USE_ASYNC=true
 ZSH_HIGHLIGHT_MAXLENGTH=300
 
 fpath=(
-  "$DOTFILES_PATH/shell/zsh/themes"
-  "$DOTFILES_PATH/shell/zsh/autocompletions"
-  "$SLOTH_PATH/shell/zsh/themes"
-  "$SLOTH_PATH/shell/zsh/completions"
+  "${DOTFILES_PATH}/shell/zsh/themes"
+  "${DOTFILES_PATH}/shell/zsh/autocompletions"
+  "${SLOTH_PATH}/shell/zsh/themes"
+  "${SLOTH_PATH}/shell/zsh/completions"
   "${fpath[@]}"
 )
 
@@ -53,8 +53,8 @@ autoload -Uz promptinit && promptinit
 prompt "${SLOTH_THEME:-codely}"
 
 #shellcheck source=/dev/null
-. "$SLOTH_PATH/shell/zsh/bindings/dot.zsh"
+. "${SLOTH_PATH}/shell/zsh/bindings/dot.zsh"
 #shellcheck source=/dev/null
-. "$SLOTH_PATH/shell/zsh/bindings/reverse_search.zsh"
+. "${SLOTH_PATH}/shell/zsh/bindings/reverse_search.zsh"
 #shellcheck source=/dev/null
-. "$DOTFILES_PATH/shell/zsh/key-bindings.zsh"
+. "${DOTFILES_PATH}/shell/zsh/key-bindings.zsh"

--- a/shell/zsh/init.sh
+++ b/shell/zsh/init.sh
@@ -44,6 +44,7 @@ fpath=(
 
 # Brew ZSH Completions
 if type brew &>/dev/null; then
+  fpath+=("$(brew --prefix)/share/zsh-completions")
   fpath+=("$(brew --prefix)/share/zsh/site-functions")
 fi
 

--- a/shell/zsh/init.sh
+++ b/shell/zsh/init.sh
@@ -43,9 +43,9 @@ fpath=(
 )
 
 # Brew ZSH Completions
-if type brew &>/dev/null; then
-  fpath+=("$(brew --prefix)/share/zsh-completions")
-  fpath+=("$(brew --prefix)/share/zsh/site-functions")
+if [[ -n "${HOMEBREW_PREFIX:-}" ]]; then
+  fpath+=("${HOMEBREW_PREFIX}/share/zsh-completions")
+  fpath+=("${HOMEBREW_PREFIX}/share/zsh/site-functions")
 fi
 
 


### PR DESCRIPTION
* Removed non needed stuff in inits
* Improved how `brew` is detected  in `zsh` and `bash` loaders
* Moved to the end the `unset` of initialiser variables
* Improved `dot shell zsh fix_permissions` and `dot shell zsh reload_completions`