### PR TITLE
[Feature] Package managers features and recipes

### DIFF
--- a/scripts/core/src/_main.sh
+++ b/scripts/core/src/_main.sh
@@ -3,7 +3,7 @@
 if ! ${DOT_MAIN_SOURCED:-false}; then
   # platform and output should be at the first place because they are used
   # in other libraries
-  for file in "${SLOTH_PATH:-$DOTLY_PATH}"/scripts/core/src/{platform,output,args,array,async,collections,documentation,dot,files,git,json,log,package,registry,script,str,yaml}.sh; do
+  for file in "${SLOTH_PATH:-$DOTLY_PATH}"/scripts/core/src/{platform,output,args,array,async,collections,documentation,dot,files,git,json,log,package,registry,script,str,yaml,wrapped}.sh; do
     #shellcheck source=/dev/null
     . "$file" || exit 5
   done

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -102,7 +102,6 @@ install_linux_custom() {
   if ! $any_pkgmgr; then
     registry::install "brew" | log::file "Trying to install brew"
   fi
-  
 
   output::answer "Installing Linux Packages"
   custom::install build-essential coreutils findutils python3-pip

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -174,7 +174,9 @@ package::command() {
   if package::command_exists "$package_manager" "${command}"; then
     package::load_manager "$package_manager"
     if [[ "$command" == "install" ]]; then
-      "${package_manager}::${command}" "${args[@]:-}" | log::file "Trying to install ${args[*]} using $package_manager" || return
+      "${package_manager}::${command}" "${args[@]:-}" 2>&1 | log::file "Installing ${args[*]} using $package_manager" || return
+    elif [[ "$command" == "uninstall" ]]; then
+      "${package_manager}::${command}" "${args[@]:-}" 2>&1 | log::file "Uninstalling ${args[*]} using $package_manager" || return
     else
       "${package_manager}::${command}" "${args[@]:-}"
     fi
@@ -375,7 +377,7 @@ package::_uninstall() {
   if [[ -n "$(registry::recipe_exists "$package_name")" ]] && registry::command_exists "$package_name" "uninstall"; then
     registry::command "$package_name" "uninstall" "$@" && ! registry::is_installed "$package_name"
   elif package::command_exists "$package_manager" "uninstall"; then
-    package::command "$package_manager" "uninstall" "$package_name" "$@" && package::is_installed "$package_name"
+    package::command "$package_manager" "uninstall" "$package_name" "$@" && ! package::is_installed "$package_name"
   fi
 }
 
@@ -391,13 +393,20 @@ package::uninstall() {
   local package_manager
   [[ $# -lt 1 ]] && return 1
   local -r package_name="$1"
+  shift
 
-  ! package::is_installed "$package_name" && return # Uninstalled because it is not installed
+  local -r recipe_path="$(registry::recipe_exists "$package_name")"
 
-  package_manager="${2:-$(package::which_package_manager "$package_name" || echo -n)}"
-  [[ -z "$package_manager" ]] && return 1 # Could not determine which package manager to be used
+  if [[ -f "$recipe_path" ]] && registry::command_exists "$package_name" "uninstall"; then
+    registry::command "$package_name" "uninstall" "$@" && ! registry::is_installed "$package_name"
+  else
+    package_manager="${2:-$(package::which_package_manager "$package_name" || echo -n)}"
+    [[ -z "$package_manager" ]] && return 1 # Could not determine which package manager to be used
 
-  package::_uninstall "$package_manager" "$package_name" "${@:3}"
+    if package::command_exists "$package_manager" "uninstall"; then
+      package::command "$package_manager" "uninstall" "$package_name" "$@" && ! package::is_installed "$package_name"
+    fi
+  fi
 }
 
 #;

--- a/scripts/core/src/platform.sh
+++ b/scripts/core/src/platform.sh
@@ -68,7 +68,11 @@ platform::get_arch() {
       architecture="ppc64"
       ;;
     i?86)
-      architecture="x86"
+      if platform::is_macos && sysctl hw.optional.x86_64 | grep -q ': 1$'; then
+        architecture="amd64"
+      else
+        architecture="x86"
+      fi
       ;;
   esac
 

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -74,9 +74,18 @@ registry::command() {
   [[ -z "$recipe" || -z "$command" ]] && return 1
   shift 2
 
-  registry::command_exists "$recipe" "$command" &&
-    registry::load_recipe "$recipe" &&
-    "$recipe_command" "$@"
+  if
+    registry::command_exists "$recipe" "$command" &&
+    registry::load_recipe "$recipe"
+  then
+    if [[ "$command" == "install" ]]; then
+      "$recipe_command" "$@" | log::file "Installing package \`$recipe\` using registry"
+    else
+      "$recipe_command" "$@"
+    fi
+  else
+    return 1
+  fi
 }
 
 #;

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -99,7 +99,7 @@ registry::install() {
 # @param string recipe
 # @return boolean
 #"
-registry::install() {
+registry::uninstall() {
   local -r recipe="${1:-}"
   local -r command="uninstall"
   [[ -z "$recipe" ]] && return 1

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -79,7 +79,9 @@ registry::command() {
       registry::load_recipe "$recipe"
   then
     if [[ "$command" == "install" ]]; then
-      "$recipe_command" "$@" | log::file "Installing package \`$recipe\` using registry"
+      "$recipe_command" "$@" 2>&1 | log::file "Installing package \`$recipe\` using registry"
+    elif [[ "$command" == "uninstall" ]]; then
+      "$recipe_command" "$@" 2>&1 | log::file "Uninstalling package \`$recipe\` using registry"
     else
       "$recipe_command" "$@"
     fi

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -76,7 +76,7 @@ registry::command() {
 
   if
     registry::command_exists "$recipe" "$command" &&
-    registry::load_recipe "$recipe"
+      registry::load_recipe "$recipe"
   then
     if [[ "$command" == "install" ]]; then
       "$recipe_command" "$@" | log::file "Installing package \`$recipe\` using registry"

--- a/scripts/core/src/wrapped.sh
+++ b/scripts/core/src/wrapped.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+wrapped::sed() {
+  if command -v gsed &> /dev/null; then
+    "$(command -v gsed)" "$@"
+  elif [[ -f "/usr/local/opt/gnu-sed/libexec/gnubin/sed" ]]; then
+    /usr/local/opt/gnu-sed/libexec/gnubin/sed "$@"
+  elif platform::is_bsd || platform::is_macos && command -v sed &> /dev/null; then
+    # Any other BSD should be added to this check
+    "$(command -v sed)" '' "$@"
+  elif command -v sed &> /dev/null; then
+    "$(command -v sed)" "$@"
+  else
+    return 1
+  fi
+}

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -86,7 +86,7 @@ else
 fi
 
 # Force to use package manager, skip recipe always
-if [[ -z "${FORCED_PKGMGR}" ]]; then
+if [[ -n "${package_manager:-}" ]]; then
   # Used in package::command
   #shellcheck disable=SC2034
   FORCED_PKGMGR="${package_manager:-}"
@@ -119,10 +119,11 @@ package::is_installed "$package_name" && log::success "$package_name already ins
 
 # If there is a recipe for the package use it
 if ! ${skip_recipe:-false} &&
-  package::install_recipe_first "$package_name" "${FORCED_PKGMGR:-}" 2>&1; then
-  output::write "✅ \`$package_name\` installed"
-
-  exit 0
+  [[ -n "$(registry::recipe_exists "$package_name")" ]]; then
+  if registry::install "$package_name"; then
+    output::write "✅ \`$package_name\` installed"
+    exit 0
+  fi
 else
   package::install "$package_name" "${FORCED_PKGMGR:-}" 2>&1 || true
 

--- a/scripts/package/install
+++ b/scripts/package/install
@@ -1,1 +1,137 @@
-add
+#!/usr/bin/env bash
+
+#shellcheck disable=SC1091
+. "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
+
+##? Install a package
+##?
+##? Usage:
+##?    add -v | --version
+##?    add -h | --help
+##?    add [-s | --skip-recipe] [--pkgmgr <package_manager>] <packages_names>...
+##?
+##? Options:
+##?    -h --help         Show script help
+##?    -v --version      Show script version
+##?    -s --skip-recipe  Skip the receipe and force to use a package manager, this omit any recipe
+##?    --pkgmgr          Force to use a package manager, for example: cargo
+##?
+##? SCRIPT_VERSION 3.1.0
+if ! ${DOTLY_INSTALLER:-false} && package::is_installed "docpars"; then
+  docs::parse "$@"
+  _all_args=("$@")
+
+  # There is an issue in docpars when using arrays
+  if ! ${pkgmgr:-false} && [[ -n "${package_manager}" ]]; then
+    packages_names=(
+      "$package_manager"
+      "${packages_names[@]}"
+    )
+    package_manager=""
+  fi
+else
+  _all_args=("$@")
+  package_name=""
+  version=false
+  help=false
+  skip_recipe=false
+  package_manager=""
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --skipe-recipe | -s)
+        skip_recipe=true
+        shift
+        ;;
+      --pkgmgr)
+        package_manager="$2"
+        shift 2
+        ;;
+      --version | -v)
+        version=true
+        shift
+        ;;
+      --help | -h)
+        help=true
+        shift
+        ;;
+      *)
+        packages_names=("$@")
+        break 2
+        ;;
+    esac
+  done
+fi
+
+# Multiple package installation
+number_of_packages="${#packages_names[@]}"
+only_args_number=$((${#_all_args[@]} - number_of_packages))
+given_options=("${_all_args[@]:0:$only_args_number}")
+
+if [[ $number_of_packages -gt 1 ]]; then
+  any_error=0
+  for pkg in "${packages_names[@]}"; do
+    if [[ ${#given_options[@]} -gt 0 ]]; then
+      "${SLOTH_PATH:-$DOTLY_PATH}/bin/dot" package add "${given_options[@]}" "$pkg" || any_error=1
+    else
+      "${SLOTH_PATH:-$DOTLY_PATH}/bin/dot" package add "$pkg" || any_error=1
+    fi
+  done
+  # Exit here because we want to execute them in order
+  exit $any_error
+elif [[ $number_of_packages -eq 1 ]]; then
+  package_name="$(echo "${packages_names[*]}" | str::to_lower | xargs)"
+else
+  output::error "You should provide at least one package to be installed"
+  exit 1
+fi
+
+# Force to use package manager, skip recipe always
+if [[ -n "${package_manager:-}" ]]; then
+  # Used in package::command
+  #shellcheck disable=SC2034
+  FORCED_PKGMGR="${package_manager:-}"
+  skip_recipe=true
+fi
+
+if ${version:-}; then
+  output::write "${SCRIPT_NAME} v${SCRIPT_VERSION}"
+  exit 0
+elif ${help:-}; then
+  grep '^##?' "$0" | tr '##? ' ' '
+  exit 0
+elif [[ -z "${package_name:-}" ]]; then
+  output::error "No package name provided"
+  exit 1
+fi
+
+# If the package is not docpars and docpars is not installed
+if [[ "$package_name" != "docpars" && "$package_name" != "cargo" ]] && ! package::is_installed "docpars"; then
+  script::depends_on docpars
+fi
+
+# Load cargo PATH
+if [[ -f "$HOME/.cargo/env" ]]; then
+  . "$HOME/.cargo/env"
+fi
+
+# Check if package is installed
+package::is_installed "$package_name" && log::success "$package_name already installed" && exit 0
+
+# If there is a recipe for the package use it
+if ! ${skip_recipe:-false} &&
+  [[ -n "$(registry::recipe_exists "$package_name")" ]]; then
+  if registry::install "$package_name"; then
+    output::write "✅ \`$package_name\` installed"
+    exit 0
+  fi
+else
+  package::install "$package_name" "${FORCED_PKGMGR:-}" 2>&1 || true
+
+  if package::is_installed "$package_name"; then
+    output::write "✅ \`$package_name\` installed"
+
+    exit 0
+  fi
+fi
+
+output::write "❌ \`$package_name\` could not be installed" && exit 1

--- a/scripts/package/remove
+++ b/scripts/package/remove
@@ -13,14 +13,19 @@ uninstall_package_output() {
   if ! package::is_installed "$package_name"; then
     output::answer "Package \`$package_name\` is not installed"
   else
-    package::uninstall "$package_name" | log::file "Trying to remove \`$package_name\`"
+    uninstall_package_force "$package_name"
+  fi
+}
 
-    if ! package::is_installed "$package_name"; then
-      output::answer "Package \`$package_name\` was uninstalled"
-    else
-      output::error "Package \`$package_name\` could not be uninstalled"
-      return 1
-    fi
+uninstall_package_force() {
+  [[ -z "${1:-}" ]] && return 1
+  local -r package_name="$1"
+
+  if package::uninstall "$package_name" && ! package::is_installed "$package_name"; then
+    output::answer "Package \`$package_name\` was uninstalled"
+  else
+    output::error "Package \`$package_name\` could not be uninstalled"
+    return 1
   fi
 }
 
@@ -30,11 +35,16 @@ uninstall_package_output() {
 ##? Usage:
 ##?   delete [-h | --help]
 ##?   delete [-v | --version]
-##?   delete <packages_names>...
+##?   delete [-f | --force] <packages_names>...
 ##?
 ##? Options:
 ##?   -h --help     Show this help
 ##?   -v --version  Show the program version
+##?   -f --force    Does not check if package is installed before uninstalling.
+##?                 If it is a recipe and has uninstall function it will be
+##?                 executed but if the package is installed with any package
+##?                 manager and could not found which one was used it won't
+##?                 execute any uninstall command.
 ##?
 ##? Author:
 ##?   Gabriel Trabanco Llano <gtrabanco@users.noreply.github.com>
@@ -51,10 +61,18 @@ fi
 
 output_code=0
 if [[ ${#packages_names[@]} -eq 1 ]]; then
-  uninstall_package_output "${packages_names[*]}" || output_code=1
+  if ${force:-false}; then
+    uninstall_package_force "${packages_names[*]}" || output_code=1
+  else
+    uninstall_package_output "${packages_names[*]}" || output_code=1
+  fi
 else
   for package_name in "${packages_names[@]}"; do
-    uninstall_package_output "$package_name" || output_code=1
+    if ${force:-false}; then
+      uninstall_package_force "$package_name" || output_code=1
+    else
+      uninstall_package_output "$package_name" || output_code=1
+    fi
   done
 fi
 

--- a/scripts/package/src/package_managers/cargo.sh
+++ b/scripts/package/src/package_managers/cargo.sh
@@ -63,6 +63,9 @@ cargo::update_all() {
 
 cargo::update_apps() {
   local outdated_app app_new_version app_old_version cargo_has_updated_apps=false
+
+  script::depends_on cargo-update
+  
   cargo::has_updated() {
     cargo_has_updated_apps=true
   }

--- a/scripts/package/src/package_managers/cargo.sh
+++ b/scripts/package/src/package_managers/cargo.sh
@@ -78,7 +78,7 @@ cargo::update_apps() {
     app_new_version="$(echo "$row" | awk '{print $3}')"
 
     [[ -z "$row" || $outdated_app == "Package" ]] && continue
-    cargo::_helper_has_updated 1
+    cargo::has_updated
 
     output::write "📦 $outdated_app"
     output::write " └ $app_old_version -> $app_new_version"

--- a/scripts/package/src/package_managers/cargo.sh
+++ b/scripts/package/src/package_managers/cargo.sh
@@ -65,7 +65,7 @@ cargo::update_apps() {
   local outdated_app app_new_version app_old_version cargo_has_updated_apps=false
 
   script::depends_on cargo-update
-  
+
   cargo::has_updated() {
     cargo_has_updated_apps=true
   }

--- a/scripts/package/src/package_managers/dnf.sh
+++ b/scripts/package/src/package_managers/dnf.sh
@@ -36,7 +36,7 @@ dnf::package_exists() {
   [[ -z "${1:-}" ]] && return 1
   local -r package_name="${1:-}"
   local -r arch="${SLOT_ARCH:-$(uname -m)}"
-  dnf search -q "$package_name" 2>/dev/null | awk '{print $1}' | grep  -qw "^${package_name}.${arch}"
+  dnf search -q "$package_name" 2> /dev/null | awk '{print $1}' | grep -qw "^${package_name}.${arch}"
 }
 
 dnf::cleanup() {
@@ -49,7 +49,7 @@ dnf::update_apps() {
   for outdated_app in $(dnf::outdated_app); do
     outdated_app_name="${outdated_app%%.*}"
     outdated_app_full_info="$(dnf info "$outdated_app_name" | cut -d " " -f 3-)"
-    
+
     outdated_app_version="$(echo "$outdated_app_info" | head -n 5 | tail -n 1)"
     outdated_app_info="$(outdated_app_full_info | head -n 9 | tail -n 1)"
     outdated_app_url="$(outdated_app_full_info | head -n 10 | tail -n 1)"
@@ -78,9 +78,9 @@ dnf::dump() {
   DNF_DUMP_FILE_PATH="${1:-$DNF_DUMP_FILE_PATH}"
 
   if package::common_dump_check apt "$DNF_DUMP_FILE_PATH"; then
-    dnf repoquery --qf '%{name}' --userinstalled \
-      | grep -v -- '-debuginfo$' \
-      | grep -v '^\(kernel-modules\|kernel\|kernel-core\|kernel-devel\)$' | tee "$DNF_DUMP_FILE_PATH" | log::file "Exporting ${dnf_title} packages"
+    dnf repoquery --qf '%{name}' --userinstalled |
+      grep -v -- '-debuginfo$' |
+      grep -v '^\(kernel-modules\|kernel\|kernel-core\|kernel-devel\)$' | tee "$DNF_DUMP_FILE_PATH" | log::file "Exporting ${dnf_title} packages"
 
     return 0
   fi

--- a/scripts/package/src/package_managers/dnf.sh
+++ b/scripts/package/src/package_managers/dnf.sh
@@ -30,3 +30,25 @@ dnf::is_installed() {
     [[ -n "${1:-}" ]] && platform::command_exists rpm && rpm -qa | grep -qw "${1:-}"
   fi
 }
+
+dnf::dump() {
+  DNF_DUMP_FILE_PATH="${1:-$DNF_DUMP_FILE_PATH}"
+
+  if package::common_dump_check apt "$DNF_DUMP_FILE_PATH"; then
+    dnf repoquery --qf '%{name}' --userinstalled \
+      | grep -v -- '-debuginfo$' \
+      | grep -v '^\(kernel-modules\|kernel\|kernel-core\|kernel-devel\)$' | tee "$DNF_DUMP_FILE_PATH" | log::file "Exporting ${dnf_title} packages"
+
+    return 0
+  fi
+
+  return 1
+}
+
+dnf::import() {
+  DNF_DUMP_FILE_PATH="${1:-$DNF_DUMP_FILE_PATH}"
+
+  if package::common_import_check apt "$DNF_DUMP_FILE_PATH"; then
+    xargs sudo dnf -y install < "$DNF_DUMP_FILE_PATH" | log::file "Importing ${dnf_title} packages"
+  fi
+}

--- a/scripts/package/src/package_managers/pip.sh
+++ b/scripts/package/src/package_managers/pip.sh
@@ -24,7 +24,7 @@ pip::uninstall() {
   [[ -n "${1:-}" ]] && pip::is_available && pip3 uninstall "$@"
 }
 
-pip::update_all() {
+pip::update_apps() {
   outdated=$(pip3 list --outdated | tail -n +3)
 
   if [ -n "$outdated" ]; then
@@ -48,6 +48,16 @@ pip::update_all() {
   else
     output::answer "Already up-to-date"
   fi
+}
+
+pip::self_update() {
+  pip3 install --upgrade pip --user
+}
+
+pip::update_all() {
+  ! pip::is_available && return 1
+  pip::self_update
+  pip::update_apps
 }
 
 pip::dump() {

--- a/scripts/package/src/package_managers/pip.sh
+++ b/scripts/package/src/package_managers/pip.sh
@@ -8,7 +8,7 @@ pip::is_available() {
 }
 
 pip::is_installed() {
-  [[ -n "${1:-}" ]] && pip3 show "$1" &> /dev/null
+  [[ -n "${1:-}" ]] && python3 -m pip show "$1" &> /dev/null
 }
 
 # Not define the function because it is not possible to do it with pip
@@ -17,22 +17,22 @@ pip::is_installed() {
 # }
 
 pip::install() {
-  [[ -n "${1:-}" ]] && pip::is_available && pip3 install --no-cache-dir "$@"
+  [[ -n "${1:-}" ]] && pip::is_available && python3 -m pip install --no-cache-dir "$@"
 }
 
 pip::uninstall() {
-  [[ -n "${1:-}" ]] && pip::is_available && pip3 uninstall --yes "$@"
+  [[ -n "${1:-}" ]] && pip::is_available && python3 -m pip uninstall --yes "$@"
 }
 
 pip::update_apps() {
-  outdated=$(pip3 list --outdated | tail -n +3)
+  outdated=$(python3 -m pip list --outdated | tail -n +3)
 
   if [ -n "$outdated" ]; then
     echo "$outdated" | while IFS= read -r outdated_app; do
       package=$(echo "$outdated_app" | awk '{print $1}')
       current_version=$(echo "$outdated_app" | awk '{print $2}')
       new_version=$(echo "$outdated_app" | awk '{print $3}')
-      info=$(pip3 show "$package")
+      info=$(python3 -m pip show "$package")
 
       summary=$(echo "$info" | head -n3 | tail -n1 | sed 's/Summary: //g')
       url=$(echo "$info" | head -n4 | tail -n1 | sed 's/Home-page: //g')
@@ -51,7 +51,7 @@ pip::update_apps() {
 }
 
 pip::self_update() {
-  pip3 install --upgrade pip --user
+  python3 -m pip install --upgrade --user pip
 }
 
 pip::update_all() {
@@ -63,8 +63,8 @@ pip::update_all() {
 pip::dump() {
   PYTHON_DUMP_FILE_PATH="${1:-$PYTHON_DUMP_FILE_PATH}"
 
-  if package::common_dump_check pip3 "$PYTHON_DUMP_FILE_PATH"; then
-    pip3 freeze | tee "$PYTHON_DUMP_FILE_PATH" | log::file "Exporting ${pip_title} packages"
+  if package::common_dump_check python3 -m pip "$PYTHON_DUMP_FILE_PATH"; then
+    python3 -m pip freeze | tee "$PYTHON_DUMP_FILE_PATH" | log::file "Exporting ${pip_title} packages"
 
     return 0
   fi
@@ -75,8 +75,8 @@ pip::dump() {
 pip::import() {
   PYTHON_DUMP_FILE_PATH="${1:-$PYTHON_DUMP_FILE_PATH}"
 
-  if package::common_import_check pip3 "$PYTHON_DUMP_FILE_PATH"; then
-    pip3 install -r "$PYTHON_DUMP_FILE_PATH" | log::file "Importing ${pip_title} packages"
+  if package::common_import_check python3 -m pip "$PYTHON_DUMP_FILE_PATH"; then
+    python3 -m pip install -r "$PYTHON_DUMP_FILE_PATH" | log::file "Importing ${pip_title} packages"
 
     return 0
   fi

--- a/scripts/package/src/package_managers/registry.sh
+++ b/scripts/package/src/package_managers/registry.sh
@@ -43,7 +43,6 @@ registry::upgrade() {
 
   output::empty_line
   registry::_recipe_info "$recipe"
-  output::empty_line
 
   if registry::command_exists "$recipe" "is_outdated"; then
     if registry::is_outdated "$recipe"; then
@@ -55,7 +54,8 @@ registry::upgrade() {
     output::empty_line
 
   elif registry::command_exists "$recipe" "upgrade"; then
-    output::answer "Can not check if ${recipe_title} is outdated, trying to update it."
+    output::empty_line
+    output::answer "Can not check if \`${recipe_title}\` is outdated, trying to update it."
     registry::command "$recipe" "upgrade" 2>&1 | log::file "Updating ${registry_title} app: $(registry::_recipe_title)"
     output::empty_line
   fi

--- a/scripts/package/src/recipes/brew.sh
+++ b/scripts/package/src/recipes/brew.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#shellcheck disable=SC2034
 
 brew::execute_from_url() {
   [[ -z "${1:-}" ]] && return 1
@@ -31,32 +32,51 @@ brew::install() {
     if sudo -v; then
       apt install -y build-essential procps curl file git
     fi
-  elif platform::is_linux && platform::is_arm; then
+  elif [[ $(platform::get_arch) != "amd64" ]] && ! platform::is_macos_arm; then
     output::error "Brew is not supported"
     return 1
-  else
+  fi
+  brew::execute_from_url "$brew_install_script"
+
+  if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+  elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="${HOME}/.linuxbrew/bin/brew"
+  elif [[ -x "/opt/homebrew/bin/brew" ]]; then
+    BREW_BIN="/opt/homebrew/bin/brew"
+  elif [[ -x "/usr/local/bin/brew" ]]; then
+    BREW_BIN="/usr/local/bin/brew"
+  elif command -v brew &> /dev/null; then
+    BREW_BIN="$(command -v brew)"
   fi
 
-if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
-  BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
-elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
-  BREW_BIN="${HOME}/.linuxbrew/bin/brew"
-elif [[ -x "/usr/local/bin/brew" ]]; then
-  BREW_BIN="/usr/local/bin/brew"
-elif command -v brew &> /dev/null; then
-  BREW_BIN="$(command -v brew)"
-fi
+  HOMEBREW_PREFIX="$("$BREW_BIN" --prefix)"
+  HOMEBREW_CELLAR="${HOMEBREW_PREFIX}/Cellar"
+  HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
 
-  if platform::is_macos_arm; then
-    export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
-  elif [[ -d ""]]
-  else
-    export PATH="$PATH:/usr/local/bin"
-  fi
-
+  PATH="${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:${PATH}"
+  export PATH HOMEBREW_PREFIX HOMEBREW_CELLAR HOMEBREW_REPOSITORY
 }
 
 brew::uninstall() {
   local -r brew_uninstall_script="https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh"
-  script::depends_on curl
+  brew::execute_from_url "$brew_uninstall_script"
 }
+
+brew::is_installed() {
+  if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+  elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="${HOME}/.linuxbrew/bin/brew"
+  elif [[ -x "/opt/homebrew/bin/brew" ]]; then
+    BREW_BIN="/opt/homebrew/bin/brew"
+  elif [[ -x "/usr/local/bin/brew" ]]; then
+    BREW_BIN="/usr/local/bin/brew"
+  elif command -v brew &> /dev/null; then
+    BREW_BIN="$(command -v brew)"
+  fi
+
+  [[ -n "$BREW_BIN" ]]
+}
+
+# Brew update is done as package manager

--- a/scripts/package/src/recipes/brew.sh
+++ b/scripts/package/src/recipes/brew.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+brew::execute_from_url() {
+  [[ -z "${1:-}" ]] && return 1
+  if platform::command_exists curl; then
+    bash < <(curl -fsSL "$1")
+  elif platform::command_exists wget; then
+    bash < <(wget -q0 - "$1")
+  else
+    script::depends_on curl
+
+    if platform::command_exists curl; then
+      brew::execute_from_url "$1"
+      return $?
+    else
+      return 1
+    fi
+  fi
+}
+
+brew::install() {
+  local -r brew_install_script="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
+  if platform::command_exists yum; then
+    if sudo -v; then
+      yes | sudo yum install group 'Development tools'
+      yes | sudo yum install procps-ng curl file git
+      yes | sudo yum install libxcrypt-compat # needed by Fedora 30 and up
+    fi
+  elif platform::command_exists apt; then
+    if sudo -v; then
+      apt install -y build-essential procps curl file git
+    fi
+  elif platform::is_linux && platform::is_arm; then
+    output::error "Brew is not supported"
+    return 1
+  else
+  fi
+
+if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+  BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
+  BREW_BIN="${HOME}/.linuxbrew/bin/brew"
+elif [[ -x "/usr/local/bin/brew" ]]; then
+  BREW_BIN="/usr/local/bin/brew"
+elif command -v brew &> /dev/null; then
+  BREW_BIN="$(command -v brew)"
+fi
+
+  if platform::is_macos_arm; then
+    export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
+  elif [[ -d ""]]
+  else
+    export PATH="$PATH:/usr/local/bin"
+  fi
+
+}
+
+brew::uninstall() {
+  local -r brew_uninstall_script="https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh"
+  script::depends_on curl
+}

--- a/scripts/package/src/recipes/brew.sh
+++ b/scripts/package/src/recipes/brew.sh
@@ -12,7 +12,6 @@ brew::execute_from_url() {
 
     if platform::command_exists curl; then
       brew::execute_from_url "$1"
-      return $?
     else
       return 1
     fi

--- a/scripts/package/src/recipes/cargo.sh
+++ b/scripts/package/src/recipes/cargo.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
 cargo::install() {
-  {
-    platform::command_exists brew && brew install rust 2>&1 | log::file "Installing build-essential" && return 0
-  } || true
-
-  if platform::command_exists apt; then
-    sudo apt install -y build-essential 2>&1 | log::file "Installing apt build-essential"
+  if ! platform::is_macos; then
+    package::install build-essential
   fi
 
-  curl https://sh.rustup.rs -sSf | sh -s -- -y 2>&1 | log::file "Installing rust from sources"
+  curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path 2>&1 | log::file "Installing rust from sources"
 
   #shellcheck disable=SC1091
   [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"

--- a/scripts/package/src/recipes/curl.sh
+++ b/scripts/package/src/recipes/curl.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+curl::install() {
+  if [[ ${SLOTH_OS:-$(uname -s)} == "Linux" ]]; then
+    script::depends_on build-essential
+  fi
+
+  if command -v package::install &> /dev/null; then
+    package::install "curl"
+  elif [[ -x "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" ]]; then
+    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add curl
+  fi
+
+  cur::is_installed
+}
+
+curl::is_installed() {
+  platform::command_exists curl
+}

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -5,9 +5,9 @@ nix::execute_from_url() {
   local -r url="$1"
   shift
   if platform::command_exists curl; then
-    sh <(curl -L "$url") --no-daemon "$@"
+    sh <(curl -L "$url") --no-daemon "$@" 2>&1
   elif platform::command_exists wget; then
-    sh <(curl -q0 - "$url") --no-daemon "$@"
+    sh <(curl -q0 - "$url") --no-daemon "$@" 2>&1
   else
     script::depends_on curl
 
@@ -23,7 +23,7 @@ nix::macos_version_apfs() {
   ! platform::is_macos && return 1
 
   case "$(platform::macos_version)" in
-    "10.4"*| "10.5"* | "10.6"* | "10.7"* | "10.8"* | "10.9"* | "10.10"* | "10.11"* | "10.12" | "10.13" | "10.14") return 1
+    "10.4"* | "10.5"* | "10.6"* | "10.7"* | "10.8"* | "10.9"* | "10.10"* | "10.11"* | "10.12" | "10.13" | "10.14") return 1 ;;
   esac
 }
 
@@ -31,17 +31,20 @@ nix::install() {
   local -r nix_install_script="https://nixos.org/nix/install"
 
   case "$(uname -s).$(uname -m)" in
-    linux.x86_64 | linux.i?86 | linux.aarch64 | darwin.x86_64 | darwin.arm64)
+    Linux.x86_64 | Linux.i?86 | Linux.aarch64 | Darwin.x86_64 | Darwin.arm64)
       # Can be installed
       ;;
     *)
+      output::error "Nix is not compatible with your system"
       return 1
       ;;
   esac
 
   if nix::macos_version_apfs; then
+    output::answer "Installing macOS APFS version of nix package manager"
     nix::execute_from_url "$nix_install_script" --darwin-use-unencrypted-nix-store-volume
   else
+    output::answer "Installing nix package manager"
     nix::execute_from_url "$nix_install_script"
   fi
 
@@ -54,7 +57,7 @@ nix::install() {
 nix::uninstall() {
   if sudo -v; then
     sudo rm -rf /etc/profile/nix.sh /etc/nix /nix ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels
-    rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &>/dev/null
+    rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &> /dev/null
   fi
 
   if platform::is_linux; then
@@ -69,10 +72,10 @@ nix::uninstall() {
     sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     output::write "To finish the installation you must manually do these steps:"
-    output::answer "1. Remove the entry from fstab using \`sudo vifs\`" 
+    output::answer "1. Remove the entry from fstab using \`sudo vifs\`"
     output::answer "2. Locate the volumen that mounts \`/Nix\` by executing \`diskutil apfs list\`."
-    output::answer "3. Destroy the data volume using \`diskutil apfs deleteVolume <disk> (<disk> should be somthing similar to \`disk1s7\`)\`" 
-    output::answer "4. Execute \` sudo vim /etc/synthetic.conf\` and remove the 'nix' line or remove the entire file \`sudo rm -f /etc/synthetic.conf\`" 
+    output::answer "3. Destroy the data volume using \`diskutil apfs deleteVolume <disk> (<disk> should be somthing similar to \`disk1s7\`)\`"
+    output::answer "4. Execute \` sudo vim /etc/synthetic.conf\` and remove the 'nix' line or remove the entire file \`sudo rm -f /etc/synthetic.conf\`"
   fi
 
   ! nix::is_installed

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -5,9 +5,9 @@ nix::execute_from_url() {
   local -r url="$1"
   shift
   if platform::command_exists curl; then
-    sh <(curl -L "$url") --no-daemon "$@" 2>&1
+    sh <(curl -L "$url") "$@" 2>&1
   elif platform::command_exists wget; then
-    sh <(curl -q0 - "$url") --no-daemon "$@" 2>&1
+    sh <(curl -q0 - "$url") "$@" 2>&1
   else
     script::depends_on curl
 
@@ -27,7 +27,36 @@ nix::macos_version_apfs() {
   esac
 }
 
+nix::delete_rc_modifications_by_nix() {
+  local file
+  local -r pattern="/# added by Nix installer/d"
+  local -r files=(
+    "${HOME}/.bash_profile"
+    "${HOME}/.zshenv"
+    "/etc/bashrc"
+    "/etc/zshrc"
+  )
+
+  for file in "${files[@]}"; do
+    wrapped::sed -i "$pattern" "$file"
+  done
+}
+
+nix::menu() {
+  local PS3 title
+  [[ $# -lt 2 ]] && return
+  title="$1"; shift
+
+  output::write "$title"
+  PS3="Choose an option: "
+  select opt in "$@"; do
+    echo "$opt"
+    return
+  done
+}
+
 nix::install() {
+  local option single_user=true
   local -r nix_install_script="https://nixos.org/nix/install"
 
   case "$(uname -s).$(uname -m)" in
@@ -35,6 +64,13 @@ nix::install() {
       # Can be installed
       # Avoid modify the bash profile and zsh env
       export NIX_INSTALLER_NO_MODIFY_PROFILE=1
+      if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+        option="$(nix::menu "Select what kind of installation do you want" "Single user (default)" "Multi user")"
+        case "$option" in
+          "Multi user") single_user=false ;;
+          *) single_user=true ;;
+        esac
+      fi
       ;;
     *)
       output::error "Nix is not compatible with your system"
@@ -44,19 +80,41 @@ nix::install() {
 
   if nix::macos_version_apfs; then
     output::answer "Installing macOS APFS version of nix package manager"
-    nix::execute_from_url "$nix_install_script" --darwin-use-unencrypted-nix-store-volume
+    if $single_user; then
+      nix::execute_from_url "$nix_install_script" --no-daemon --darwin-use-unencrypted-nix-store-volume
+    else
+      nix::execute_from_url "$nix_install_script" --daemon --darwin-use-unencrypted-nix-store-volume
+    fi
   else
     output::answer "Installing nix package manager"
-    nix::execute_from_url "$nix_install_script"
+    if $single_user; then
+      nix::execute_from_url "$nix_install_script" --no-daemon
+    else
+      nix::execute_from_url "$nix_install_script" --daemon
+    fi
   fi
 
   if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
     #shellcheck disable=SC1091
-    . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+    dot::load_library "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+  elif [[ -r "/etc/profile.d/nix.sh" ]]; then
+    dot::load_library "/etc/profile.d/nix.sh"
+  else
+    output::error "Nix was not installed"
+    return 1
   fi
+
+  if platform::command_exists nix-shell; then
+    output::answer "Nix initial configuration"
+    nix-shell -p nix-info --run "nix-info -m"
+  fi
+
+  output::solution "Nix for single user was installed sucessfully"
 }
 
 nix::uninstall() {
+  # TODO Automate single user uninstall
+  # TODO Adds multi user uninstall
   if sudo -v; then
     sudo rm -rf /etc/profile/nix.sh /etc/nix /nix ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels
     rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &> /dev/null
@@ -70,15 +128,34 @@ nix::uninstall() {
     sudo systemctl disable nix-daemon.service
     sudo systemctl daemon-reload
   elif platform::is_macos; then
+    if ! sudo -v; then
+      output::error "You need to run this script with sudo"
+      return 1
+    fi
     # If you are on macOS, you will need to run:
     sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    output::write "To finish the installation you must manually do these steps:"
+    local -r disk="$(mount | awk '$3 == "/nix" {print $1}')"
+    if [[ -n "$disk" ]]; then
+      diskutil apfs deleteVolume "$disk"
+    fi
+
+    output::write "Tried to have it done automatically but check these steps are done and if not, do it automatically:"
     output::answer "1. Remove the entry from fstab using \`sudo vifs\`"
     output::answer "2. Locate the volumen that mounts \`/Nix\` by executing \`diskutil apfs list\`."
     output::answer "3. Destroy the data volume using \`diskutil apfs deleteVolume <disk> (<disk> should be somthing similar to \`disk1s7\`)\`"
     output::answer "4. Execute \` sudo vim /etc/synthetic.conf\` and remove the 'nix' line or remove the entire file \`sudo rm -f /etc/synthetic.conf\`"
   fi
+
+  delete_rc_modifications_by_nix
+
+  if [[ $(wc -l < /etc/synthetic.conf) -gt 1 ]]; then
+    sudo wrapped::sed --silent -i '/^nix/d' /etc/synthetic.conf
+  else
+    sudo rm -f /etc/synthetic.conf
+  fi
+
+  sudo wrapped::sed --silent -i '/^LABEL=Nix/d' '/etc/fstab'
 
   ! nix::is_installed
 }

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -33,6 +33,8 @@ nix::install() {
   case "$(uname -s).$(uname -m)" in
     Linux.x86_64 | Linux.i?86 | Linux.aarch64 | Darwin.x86_64 | Darwin.arm64)
       # Can be installed
+      # Avoid modify the bash profile and zsh env
+      export NIX_INSTALLER_NO_MODIFY_PROFILE=1
       ;;
     *)
       output::error "Nix is not compatible with your system"

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+nix::execute_from_url() {
+  [[ -z "${1:-}" ]] && return 1
+  local -r url="$1"
+  shift
+  if platform::command_exists curl; then
+    sh <(curl -L "$url") --no-daemon "$@"
+  elif platform::command_exists wget; then
+    sh <(curl -q0 - "$url") --no-daemon "$@"
+  else
+    script::depends_on curl
+
+    if platform::command_exists curl; then
+      nix::execute_from_url "$url"
+    else
+      return 1
+    fi
+  fi
+}
+
+nix::macos_version_apfs() {
+  ! platform::is_macos && return 1
+
+  case "$(platform::macos_version)" in
+    "10.4"*| "10.5"* | "10.6"* | "10.7"* | "10.8"* | "10.9"* | "10.10"* | "10.11"* | "10.12" | "10.13" | "10.14") return 1
+  esac
+}
+
+nix::install() {
+  local -r nix_install_script="https://nixos.org/nix/install"
+
+  case "$(uname -s).$(uname -m)" in
+    linux.x86_64 | linux.i?86 | linux.aarch64 | darwin.x86_64 | darwin.arm64)
+      # Can be installed
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if nix::macos_version_apfs; then
+    nix::execute_from_url "$nix_install_script" --darwin-use-unencrypted-nix-store-volume
+  else
+    nix::execute_from_url "$nix_install_script"
+  fi
+}
+
+nix::uninstall() {
+  sudo -v
+  sudo rm -rf /etc/profile/nix.sh /etc/nix /nix ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels
+  rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &>/dev/null
+
+  if platform::is_linux; then
+    # If you are on Linux with systemd, you will need to run:
+    sudo systemctl stop nix-daemon.socket
+    sudo systemctl stop nix-daemon.service
+    sudo systemctl disable nix-daemon.socket
+    sudo systemctl disable nix-daemon.service
+    sudo systemctl daemon-reload
+  elif platform::is_macos; then
+    # If you are on macOS, you will need to run:
+    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+  fi
+
+  ! nix::is_installed
+}
+
+nix::is_installed() {
+  platform::command_exists nix
+}

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -45,7 +45,8 @@ nix::delete_rc_modifications_by_nix() {
 nix::menu() {
   local PS3 title
   [[ $# -lt 2 ]] && return
-  title="$1"; shift
+  title="$1"
+  shift
 
   output::write "$title"
   PS3="Choose an option: "

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -47,9 +47,10 @@ nix::install() {
 }
 
 nix::uninstall() {
-  sudo -v
-  sudo rm -rf /etc/profile/nix.sh /etc/nix /nix ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels
-  rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &>/dev/null
+  if sudo -v; then
+    sudo rm -rf /etc/profile/nix.sh /etc/nix /nix ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels
+    rm -rf "${HOME}/.nix-profile" "${HOME}/.nix-defexpr" "${HOME}/.nix-channels" &>/dev/null
+  fi
 
   if platform::is_linux; then
     # If you are on Linux with systemd, you will need to run:
@@ -62,6 +63,11 @@ nix::uninstall() {
     # If you are on macOS, you will need to run:
     sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    output::write "To finish the installation you must manually do these steps:"
+    output::answer "1. Remove the entry from fstab using \`sudo vifs\`" 
+    output::answer "2. Locate the volumen that mounts \`/Nix\` by executing \`diskutil apfs list\`."
+    output::answer "3. Destroy the data volume using \`diskutil apfs deleteVolume <disk> (<disk> should be somthing similar to \`disk1s7\`)\`" 
+    output::answer "4. Execute \` sudo vim /etc/synthetic.conf\` and remove the 'nix' line or remove the entire file \`sudo rm -f /etc/synthetic.conf\`" 
   fi
 
   ! nix::is_installed

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -44,6 +44,11 @@ nix::install() {
   else
     nix::execute_from_url "$nix_install_script"
   fi
+
+  if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+    #shellcheck disable=SC1091
+    . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+  fi
 }
 
 nix::uninstall() {

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -56,6 +56,10 @@ nix::menu() {
   done
 }
 
+nix::is_installed() {
+  platform::command_exists nix
+}
+
 nix::install() {
   local option single_user=true
   local -r nix_install_script="https://nixos.org/nix/install"
@@ -157,8 +161,4 @@ nix::uninstall() {
   fi
 
   ! nix::is_installed
-}
-
-nix::is_installed() {
-  platform::command_exists nix
 }

--- a/scripts/package/src/recipes/nix.sh
+++ b/scripts/package/src/recipes/nix.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-command -v wrapped::sed
-exit
-
 nix::execute_from_url() {
   [[ -z "${1:-}" ]] && return 1
   local -r url="$1"

--- a/scripts/package/src/recipes/tldr.sh
+++ b/scripts/package/src/recipes/tldr.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+tldr::is_installed() {
+  platform::command_exists tldr
+}
+
+tldr::install() {
+  ! tldr::is_installed && package::install tldr
+}
+
+tldr::is_outdated() {
+  return 0
+}
+
+tldr::upgrade() {
+  command tldr --update
+  output::answer "TLDR updated"
+}
+
+tldr::description() {
+  echo "Simplified and community-driven man pages"
+}
+
+tldr::url() {
+  echo "https://tldr.sh"
+}
+
+tldr::title() {
+  echo -n "📜 TLDR"
+}

--- a/scripts/package/src/recipes/tldr.sh
+++ b/scripts/package/src/recipes/tldr.sh
@@ -9,7 +9,12 @@ tldr::install() {
 }
 
 tldr::is_outdated() {
-  return 0
+  local -r tldr_path="${HOME}/.tldrc"
+  if [[ ! -d "$tldr_path" ]] || [[ -d "$tldr_path" ]] && files::check_if_path_is_older "$tldr_path" 7 days; then
+    return 0
+  fi
+
+  return 1
 }
 
 tldr::upgrade() {

--- a/scripts/package/src/recipes/zimfw.sh
+++ b/scripts/package/src/recipes/zimfw.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+zimfw::is_installed() {
+  [[ -d "${SLOTH_PATH:-$DOTLY_PATH}/modules/zimfw/" ]] && command -v git &> /dev/null
+}
+
+zimfw::is_outdated() {
+  [[ $(platform::semver_compare "$(zimfw::latest)" "$(zimfw::version)") -gt 0 ]]
+}
+
+zimfw::upgrade() {
+  zsh -c ". \"${HOME}/.zshrc\"; zimfw clean; zimfw update; zimfw upgrade; zimfw compile"
+}
+
+zimfw::description() {
+  echo "Zim is a Zsh configuration framework with blazing speed and modular extensions"
+}
+
+zimfw::url() {
+  echo "https://zimfw.sh"
+}
+
+zimfw::version() {
+  zsh -c ". \"${HOME}/.zshrc\"; zimfw version"
+}
+
+zimfw::latest() {
+  command git -C "${SLOTH_PATH:-$DOTLY_PATH}/modules/zimfw/" ls-remote --tags --refs origin 'v*' 2> /dev/null | awk '{print $NF}' | sed 's#refs/tags/v##g' | sort -r | head -n1
+}
+
+zimfw::title() {
+  echo -n "ZIM:FW"
+}

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -12,14 +12,23 @@ update_all_error() {
 ##? Update all packages
 ##?
 ##? Usage:
-##?   update_all
+##?   update_all [<package_managers>...]
+##?
+##? Arguments:
+##?   package_manager  Package manager to use for updating (could be registry, cargo, apt, yum, etc.)
+##?
+##? SCRIPT_VERSION "3.1.0"
 docs::parse "$@"
 
 output::h1_without_margin "♻️  Updating all the apps on your system"
 output::write "If you want to debug what's happening behind the scenes, you can execute \`dot self debug\` in parallel."
 output::empty_line
 
-for package_manager in $(package::get_all_package_managers "is_available" "update_all"); do
+if [[ -z "${package_managers[*]:-}" ]]; then
+  readarray -t package_managers < <(package::get_all_package_managers "is_available" "update_all")
+fi
+
+for package_manager in "${package_managers[@]}"; do
   package_title="${package_manager}_title"
 
   if
@@ -30,14 +39,6 @@ for package_manager in $(package::get_all_package_managers "is_available" "updat
     package::command "$package_manager" "update_all" || update_all_error "${!package_title}"
   fi
 done
-
-{
-  platform::command_exists tldr && output::h2 '📜 tldr database' && tldr --update
-} || update_all_error '📜 tldr database'
-
-{
-  output::h2 "Zim Framework" && zsh "${SLOTH_PATH:-$DOTLY_PATH}/modules/zimfw/zimfw.zsh" upgrade 2>&1 | log::file "Updating Zim"
-} || update_all_error '(Zim:FW) Zim Framework'
 
 output::empty_line
 output::solution '👌 All your packages have been successfully updated'

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -167,6 +167,12 @@ else
   echo -e "\033[0;31m\033[1mDOTLY Could not be loaded: Initializer not found for \`${SLOTH_SHELL}\`\033[0m"
 fi
 
+# If nix package manager is installed load the env
+if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+  #shellcheck disable=SC1091
+  . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+fi
+
 # Aliases
 #shellcheck source=/dev/null
 { [[ -f "$DOTFILES_PATH/shell/aliases.sh" ]] && . "$DOTFILES_PATH/shell/aliases.sh"; } || true

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -169,9 +169,15 @@ else
 fi
 
 # If nix package manager is installed load the env
+# Load single user nix installation in the shell
 if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
   #shellcheck disable=SC1091
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+
+# Load nix env when installed for all os users
+elif [[ -r "/etc/profile.d/nix.sh" ]]; then
+  #shellcheck disable=SC1091
+  . "/etc/profile.d/nix.sh"
 fi
 
 # Aliases


### PR DESCRIPTION
## Changes

* Adds new core library included in `_main.sh` named `wrapped.sh` which includes a sed caller for multi os support.
* Adds `brew` package manager installation as recipe which makes possible to install it on Linux
* Adds `nix` package manager installation as recipe.
* Added `pip` self update as package manager.
* Added `dnf` package import export, required fedora 26. Can contains issues because I could not test it, I made it using this [stackoverflow](https://unix.stackexchange.com/questions/82880/how-to-replicate-installed-package-selection-from-one-fedora-instance-to-another) as reference.
* Added to the log the output of the recipes installation.
* Added `tldr` recipe to update and install. So now you will see a cool update info.
* Added `zimfw` recipe to update (only). So now you will see a cool update info.
* If no package manager is detected for Linux, try to install `brew`
* Now required packages for Linux some of them are optional.
* Fix `registry::uninstall` were not defined and registry::install were defined twice.
* Fix an issue that causes sometimes to do not use a recipe in `dot package add`
* Fix issue pip is being invoked by an old script wrapper (see this issue in [pip github](https://github.com/pypa/pip/issues/5599))