### PR TITLE
[Feature] MacPorts support

### DIFF
--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -65,11 +65,11 @@ install_macos_custom() {
 
     output::answer "Installing mas"
     custom::install mas
-  fi
 
-  # Required packages output an error
-  if ! package::is_installed "docpars" || ! package::is_installed "python3" || ! package::is_installed "python-yq"; then
-    output::error "🚨 Any of the following packages \`docpars\`, \`python3\`, \`python-yq\` could not be installed, and are required"
+    # Required packages output an error
+    if ! package::is_installed "docpars" || ! package::is_installed "python3" || ! package::is_installed "python-yq"; then
+      output::error "🚨 Any of the following packages \`docpars\`, \`python3\`, \`python-yq\` could not be installed, and are required"
+    fi
   fi
 }
 
@@ -112,10 +112,10 @@ install_linux_custom() {
   # To make CI Checks faster this packages are only installed if not CI
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
     custom::install bash zsh hyperfine docpars zsh fzf python-yq jq
-  fi
 
-  # Required packages output an error
-  if ! package::is_installed "docpars" || ! package::is_installed "python3-pip" || ! package::is_installed "python-yq"; then
-    output::error "🚨 Any of the following packages \`docpars\`, \`python3-pip\`, \`python-yq\` could not be installed, and are required"
+    # Required packages output an error
+    if ! package::is_installed "docpars" || ! package::is_installed "python3-pip" || ! package::is_installed "python-yq"; then
+      output::error "🚨 Any of the following packages \`docpars\`, \`python3-pip\`, \`python-yq\` could not be installed, and are required"
+    fi
   fi
 }

--- a/scripts/core/src/platform.sh
+++ b/scripts/core/src/platform.sh
@@ -27,28 +27,7 @@ platform::macos_version() {
 }
 
 platform::macos_version_name() {
-  local version_name="macOS"
-
-  ! platform::is_macos && return
-
-  case "$(platform::macos_version)" in
-    "10.4"*) version_name="Mac OS X Tiger" ;;
-    "10.5"*) version_name="Mac OS X Leopard" ;;
-    "10.6"*) version_name="Mac OS X Snow Leopard" ;;
-    "10.7"*) version_name="Mac OS X Lion" ;;
-    "10.8"*) version_name="OS X Mountain Lion" ;;
-    "10.9"*) version_name="OS X Mavericks" ;;
-    "10.10"*) version_name="OS X Yosemite" ;;
-    "10.11"*) version_name="OS X El Capitan" ;;
-    "10.12"*) version_name="macOS Sierra" ;;
-    "10.13"*) version_name="macOS High Sierra" ;;
-    "10.14"*) version_name="macOS Mojave" ;;
-    "10.15"*) version_name="macOS Catalina" ;;
-    "11"*) version_name="macOS Big Sur" ;;
-    "12"*) version_name="macOS Monterey" ;;
-  esac
-
-  echo "$version_name"
+  platform::is_macos && awk '/SOFTWARE LICENSE AGREEMENT FOR macOS/' '/System/Library/CoreServices/Setup Assistant.app/Contents/Resources/en.lproj/OSXSoftwareLicense.rtf' | awk -F 'macOS ' '{print $NF}' | awk '{print substr($0, 0, length($0)-1)}'
 }
 
 platform::get_os() {

--- a/scripts/package/src/recipes/clt.sh
+++ b/scripts/package/src/recipes/clt.sh
@@ -6,7 +6,6 @@
 
 # This install function was created using brew installation script as reference
 clt::install() {
-  local answer
   if ! platform::is_macos; then
     output::error "This package is only for macOS"
     return 1

--- a/scripts/package/src/recipes/clt.sh
+++ b/scripts/package/src/recipes/clt.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Command Line Tools
+# Useful for dependencies of CLT
+# https://developer.apple.com/downloads/index.action
+
+# This install function was created using brew installation script as reference
+clt::install() {
+  local answer
+  if ! platform::is_macos; then
+    output::error "This package is only for macOS"
+    return 1
+  fi
+
+  if clt::is_installed; then
+    output::answer "Reinstall of Command Line Tools is not possible without uninstalling first"
+    return 1
+  fi
+
+  local -r placeholder="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+  /usr/bin/touch "$placeholder" # Force softwareupdate to list CLT
+
+  local -r clt_label="$(/usr/sbin/softwareupdate -l | grep -B 1 -E 'Command Line Tools' | awk -F '*' '/^ *\\*/ {print $2}' | sed -e 's/^ *Label: //' -e 's/^ *//' | sort -V -r |
+    head -n1)"
+
+  if ! /usr/bin/sudo -v -B; then
+    output::error "Can not be installed without sudo authentication first"
+    return 1
+  fi
+
+  if [[ -n "$clt_label" ]]; then
+    /usr/bin/sudo /usr/sbin/softwareupdate -i "$clt_label"
+    /usr/bin/sudo /usr/bin/xcode-select --switch "/Library/Developer/CommandLineTools"
+    /bin/rm -f "$placeholder"
+  fi
+
+  # Something was terriby wrong with the CLT installation, so we need to try with another method
+  if ! clt::is_installed; then
+    /usr/bin/xcode-select --install
+    if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+      output::write "Press any key when installation is completed..."
+      read -r -n 1
+    fi
+  fi
+
+  if ! output="$(/usr/bin/xcrun clang 2>&1)" && [[ "$output" == *"license"* ]]; then
+    output::error "Command Line Tools could not be installed because you do not have accepted the license"
+    return 1
+  fi
+
+  clt::is_installed && output::solution "Command Line Tools installed"
+}
+
+clt::is_installed() {
+  platform::is_macos && platform::command_exists /usr/bin/xcode-select && xpath=$(/usr/bin/xcode-select --print-path) && test -d "${xpath}" && test -x "${xpath}"
+}
+
+clt::uninstall() {
+  if ! clt::is_installed; then
+    return
+  fi
+
+  # Remove Command Line Tools
+  local -r clt_path="$(/usr/bin/xcode-select --print-path)"
+
+  if ! sudo -v -B; then
+    output::error "Can not uninstall without sudo"
+  fi
+
+  sudo rm -rf "${clt_path}"
+
+  ! commmand-line-tools::is_installed && output::solution "Command Line Tools uninstalled"
+}

--- a/scripts/package/src/recipes/macports.sh
+++ b/scripts/package/src/recipes/macports.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-. "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
-
 macports_repository_url="https://github.com/macports/macports-base.git"
 macports_download_base_url="https://github.com/macports/macports-base/releases/download"
 

--- a/scripts/package/src/recipes/macports.sh
+++ b/scripts/package/src/recipes/macports.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+. "${SLOTH_PATH:-$DOTLY_PATH}/scripts/core/src/_main.sh"
+
+macports_repository_url="https://github.com/macports/macports-base.git"
+macports_download_base_url="https://github.com/macports/macports-base/releases/download"
+
+macports::file_name() {
+  local version
+  ! platform::is_macos && return
+
+  local -r version_name=$(platform::macos_version_name)
+  local -r version_number=$(platform::macos_version)
+
+  if [[ ${version_number%.*} -gt 10 ]]; then
+    version="${version_number%.*}"
+  else
+    version="$version_number"
+  fi
+
+  echo "MacPorts-$(macports::latest)-$version-${version_name// /}.pkg"
+}
+
+macports::latest_download() {
+  local latest_url tmp_path
+  # macports_releases_api_url="https://api.github.com/repos/macports/macports-base/releases/latest"
+  # latest_url="$(curl -s "$macports_releases_api_url" 2>/dev/null | grep -i "$(macports::file_name)" | cut -d'"' -f 4 | grep '^https://' | grep -v '.asc$' || true)"
+  latest_url="${macports_download_base_url}/v$(macports::latest)/$(macports::file_name)"
+
+  tmp_path="$(mktemp -d)"
+  tmp_file_path="$tmp_path/$(macports::file_name)"
+  if curl -fsSL --output "$tmp_file_path" "$latest_url" && [[ -f "$tmp_file_path" ]]; then
+    echo "$tmp_file_path"
+  fi
+}
+
+macports::is_installed() {
+  [[ -x "/opt/local/bin/port" ]] || platform::is_macos && platform::command_exists port
+}
+
+macports::latest() {
+  git ls-remote --tags --refs "$macports_repository_url" 'v*' 2> /dev/null | awk '{print $NF}' | sed 's#refs/tags/v##g' | sort -r | head -n1
+}
+
+macports::install() {
+  local macports_downloaded_path
+  if ! platform::is_macos; then
+    output::write "🤔 MacPorts is only available for macOS 😕"
+    return 1
+  fi
+
+  script::depends_on clt curl
+
+  output::answer "Downloading MacPorts... This could take a while."
+  macports_downloaded_path="$(macports::latest_download)"
+
+  if [[ -f "$macports_downloaded_path" ]] && sudo -v; then
+    # Install MacPorts
+    sudo installer -pkg "$macports_downloaded_path" -target /
+    # Install MacPorts' dependencies
+    sudo /opt/local/bin/port -v selfupdate
+
+    macports::is_installed && output::solution "MacPorts installed" && output::answer "To use it restart your terminal"
+  else
+    output::error "MacPorts could not be downloaded"
+    output::empty_line
+    output::write "Try installing manually from:"
+    output::answer "https://github.com/macports/macports-base/releases/latest"
+    return 1
+  fi
+}
+
+macports::uninstall() {
+  if ! sudo -v -B; then
+    output::error "MacPorts requires sudo access"
+    return 1
+  fi
+
+  # Uninstall all port packages
+  if [[ -x "/opt/local/bin/port" ]] && /usr/bin/sudo /opt/local/bin/port -fp uninstall installed; then
+    output::write "Before uninstall, execute first (until fails):"
+    output::answer "\`sudo port -fp uninstall installed\`"
+    return 1
+  fi
+
+  output::answer "Deleting MacPorts' users and groups"
+  /usr/bin/sudo /usr/bin/dscl . -delete /Users/macports &> /dev/null
+  /usr/bin/sudo /usr/bin/dscl . -delete /Groups/macports &> /dev/null
+
+  output::answer "Deleting MacPorts' files"
+  /usr/bin/sudo /bin/rm -rf /opt/local /Applications/DarwinPorts /Applications/MacPorts
+  /usr/bin/sudo /bin/rm -rf /Library/LaunchDaemons/org.macports.* /Library/Receipts/DarwinPorts*.pkg /Library/Receipts/MacPorts*.pkg /Library/StartupItems/DarwinPortsStartup /Library/Tcl/darwinports1.0 /Library/Tcl/macports1.0
+  /usr/bin/sudo /bin/rm -rf ~/.macports
+
+  ! macports::is_installed && output::solution "Package \`MacPorts\` uninstalled"
+}

--- a/scripts/symlinks/apply
+++ b/scripts/symlinks/apply
@@ -239,8 +239,4 @@ for file in "${yaml_files[@]}"; do
   output::empty_line
 done
 
-if ${core:-false}; then
-  log::success "Core symlinks done!"
-else
-  log::success "Symlinks Done!"
-fi
+log::success "Symlinks Done!"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -85,6 +85,26 @@ elif [[ -n "${ZSH_VERSION:-}" ]]; then
 fi
 export SLOTH_UNAME SLOTH_OS SLOTH_ARCH SLOTH_SHELL
 
+###### Macports support ######
+# Load macports paths in user paths because we prefer brew over macports
+if [[ -x "/opt/local/bin/port" && -n "$BREW_PREFIX" ]]; then
+  export user_paths=(
+    "/opt/local/bin"
+    "/opt/local/sbin"
+    "${user_paths[@]}"
+  )
+  export MANPATH="/opt/local/share/man:$MANPATH"
+elif [[ -x "/opt/local/bin/port" ]]; then
+  export user_paths=(
+    "/opt/local/bin"
+    "/opt/local/sbin"
+    "${user_paths[@]}"
+  )
+  export MANPATH="/opt/local/share/man:$MANPATH"
+fi
+###### End of Macports support ######
+
+###### Brew Package manager support ######
 # BREW_BIN is necessary because maybe is not set the path where it is brew installed
 BREW_BIN=""
 # Locating brew binary
@@ -146,7 +166,9 @@ else
     "${user_paths[@]}"
   )
 fi
+###### End of Brew Package manager support ######
 
+###### PATHS ######
 # Conditional paths
 [[ -d "$HOME/.cargo/bin" ]] && path+=("$HOME/.cargo/bin")
 [[ -d "${JAVA_HOME:-}" ]] && path+=("$JAVA_HOME/bin")
@@ -159,6 +181,7 @@ path+=("/usr/bin")
 path+=("/bin")
 path+=("/usr/sbin")
 path+=("/sbin")
+###### END OF PATHS ######
 
 # Load dotly core for your current BASH
 if [[ -n "$SLOTH_SHELL" && -f "${SLOTH_PATH:-$DOTLY_PATH}/shell/${SLOTH_SHELL}/init.sh" ]]; then


### PR DESCRIPTION
* Added `Command Line Tools` recipe to resolve dependencies
* Added `MacPorts` recipe
* Modified `platform::macos_version_name` to return automatically the name of the current macOS (of course is only available on macOS)

# Important
Decided not to add MacPorts as package manager because it needs sudo to install packages, but you will have a recipe to full install/uninstall a MacPorts easily.