### PR TITLE
Speed up init-sloth

### DIFF
--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -25,18 +25,30 @@ docs::parse "$@"
 
 case $1 in
   "optimize")
-    asl_conf=$(sed 's/notice] store/critical] store/g' /etc/asl.conf)
-    sudo sh -c "echo '$asl_conf' > /etc/asl.conf"
-    echo "ASL only storing critical files!"
-
+    output::header "Cleaning stuff"
     find "$DOTFILES_PATH/shell/zsh" -name '*.zwc' -exec rm -rf {} \;
     find "$DOTFILES_PATH/shell/zsh" -name '*.old' -exec rm -rf {} \;
-    find "$DOTLY_PATH/modules/zimfw" -name '*.zwc' -exec rm -rf {} \;
-    find "$DOTLY_PATH/modules/zimfw" -name '*.old' -exec rm -rf {} \;
+    zimfw clean
+    zimfw compile
+    output::empty_line
 
-    /bin/zsh -c "source ${ZDOTDIR:-${HOME}}/.zlogin"
+    output::header "Loading zlogin"
+    /bin/zsh -c ". \"${ZDOTDIR:-${HOME}}/.zlogin\""
+    output::empty_line
 
+    output::header "Reloading zsh completions"
     "$DOTLY_PATH/bin/dot" shell zsh reload_completions
+    output::empty_line
+
+    output::header "ASL only storing critical files"
+    if sudo -v -B; then
+      asl_conf=$(sed 's/notice] store/critical] store/g' /etc/asl.conf)
+      sudo sh -c "echo '$asl_conf' > /etc/asl.conf"
+      output::empty_line
+    else
+      output::error "This final step require elevation with sudo"
+    fi
+    output::solution "Done! Restart your terminal"
     ;;
   "test_performance")
     script::depends_on hyperfine

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -45,17 +45,17 @@ fi
 GPG_TTY="$(tty || echo -n)"
 export GPG_TTY
 
+# SLOTH_PATH & DOTLY_PATH compatibility
+{ [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo "Checking DOTLY_PATH and SLOTH_PATH. We want both not just one..."; } || true
+[[ -z "${SLOTH_PATH:-}" && -n "${DOTLY_PATH:-}" ]] && SLOTH_PATH="$DOTLY_PATH"
+[[ -z "${DOTLY_PATH:-}" && -n "${SLOTH_PATH:-}" ]] && DOTLY_PATH="$SLOTH_PATH"
+
 # Sloth aliases and functions
 { [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo "Defining Sloth aliases"; } || true
 alias dotly='"$SLOTH_PATH/bin/dot"'
 alias sloth='"$SLOTH_PATH/bin/dot"'
 alias lazy='"$SLOTH_PATH/bin/dot"'
 alias s='"$SLOTH_PATH/bin/dot"'
-
-# SLOTH_PATH & DOTLY_PATH compatibility
-{ [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo "Checking DOTLY_PATH and SLOTH_PATH. We want both not just one..."; } || true
-[[ -z "${SLOTH_PATH:-}" && -n "${DOTLY_PATH:-}" ]] && SLOTH_PATH="$DOTLY_PATH"
-[[ -z "${DOTLY_PATH:-}" && -n "${SLOTH_PATH:-}" ]] && DOTLY_PATH="$SLOTH_PATH"
 
 { [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo "Loading user exports"; } || true
 { [[ -f "$DOTFILES_PATH/shell/exports.sh" ]] && . "$DOTFILES_PATH/shell/exports.sh"; } || true
@@ -113,18 +113,19 @@ fi
 ###### Brew Package manager support ######
 { [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo "Loading Brew"; } || true
 # BREW_BIN is necessary because maybe is not set the path where it is brew installed
-BREW_BIN=""
-# Locating brew binary
-if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
-  BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
-elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
-  BREW_BIN="${HOME}/.linuxbrew/bin/brew"
-elif [[ -x "/opt/homebrew/bin/brew" ]]; then
-  BREW_BIN="/opt/homebrew/bin/brew"
-elif [[ -x "/usr/local/bin/brew" ]]; then
-  BREW_BIN="/usr/local/bin/brew"
-elif command -v brew &> /dev/null; then
-  BREW_BIN="$(command -v brew)"
+if [[ -z "${BREW_BIN:-}" || ! -x "$BREW_BIN" ]]; then
+  # Locating brew binary
+  if [[ -d "/home/linuxbrew/.linuxbrew" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+  elif [[ -d "${HOME}/.linuxbrew" && -x "${HOME}/.linuxbrew/bin/brew" ]]; then
+    BREW_BIN="${HOME}/.linuxbrew/bin/brew"
+  elif [[ -x "/opt/homebrew/bin/brew" ]]; then
+    BREW_BIN="/opt/homebrew/bin/brew"
+  elif [[ -x "/usr/local/bin/brew" ]]; then
+    BREW_BIN="/usr/local/bin/brew"
+  elif command -v brew &> /dev/null; then
+    BREW_BIN="$(command -v brew)"
+  fi
 fi
 
 # Check with -x has no sense because we have done it before :)


### PR DESCRIPTION
* Added the possibility to define `BREW_BIN` to speed up around 10 ms the initilization.
* Removed the exchange between `DOTLY_PATH` & `SLOTH_PATH`, normally in scripts is recommended to use `${SLOTH_PATH:-$DOTLY_PATH}` in whatever you want compatibility with Dotly.
* Changed when define the aliases affected to the performance a little bit.
* Modified `dot shell optimize` output and how zimfw is cleaned

Its around 10 ms faster now 😅

![Screenshot 2021-07-21 at 19 27 09](https://user-images.githubusercontent.com/1969593/126532956-392bc309-e7e5-469f-a944-b3fee725c9f0.png)