### PR TITLE
[Fix] Remove & fix

### DIFF
--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -7,7 +7,7 @@ custom::install() {
     return
   fi
 
-  package::is_installed "$1" || package::install_recipe_first "$1" | log::file "Installing package $1" || output::error "Package $1 could not be installed"
+  package::is_installed "$1" || package::install "$1" | log::file "Installing package $1" || output::error "Package $1 could not be installed"
   shift
 
   if [[ $# -gt 0 ]]; then

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -362,30 +362,10 @@ package::install_recipe_first() {
 }
 
 #;
-# package::_uninstall()
-# Private helper to uninstall a package
-# @param string package_manager
-# @param string package_name
-# @param any args Additional arguments to be passed to the uninstall function
-# @return boolean True if uninstalled and false if still installed
-#"
-package::_uninstall() {
-  [[ $# -lt 2 ]] && return 1
-  local -r package_manager="$1"
-  local -r package_name="$2"
-  shift 2
-  if [[ -n "$(registry::recipe_exists "$package_name")" ]] && registry::command_exists "$package_name" "uninstall"; then
-    registry::command "$package_name" "uninstall" "$@" && ! registry::is_installed "$package_name"
-  elif package::command_exists "$package_manager" "uninstall"; then
-    package::command "$package_manager" "uninstall" "$package_name" "$@" && ! package::is_installed "$package_name"
-  fi
-}
-
-#;
 # package::uninstall()
 # Uninstall the given package, if second parameter is given it will try do it with package manager
 # @param string package_name
-# @param string package_manager Optional, if not provided will try to look up which package manager should be used
+# @param string package_manager Optional, if not provided will try to look up which package manager should be used. If you set to auto it will try to uninstall with any available package manager ignoring registry (recipes).
 # @param any args Additional arguments to be passed to uninstall function (package_manager is required then)
 # @return boolean True if uninstalled and false if still installed
 #"
@@ -400,6 +380,7 @@ package::uninstall() {
 
   if
     [[ -z "$package_manager" || "$package_manager" == "registry" || "$package_manager" == "recipe" ]] &&
+      [[ $package_manager != "auto" ]] &&
       [[ -f "$recipe_path" ]] &&
       registry::command_exists "$package_name" "uninstall"
   then

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -125,7 +125,7 @@ if ! ${skip_recipe:-false} &&
     exit 0
   fi
 else
-  package::install "$package_name" "${FORCED_PKGMGR:-}" 2>&1 || true
+  package::install "$package_name" "${FORCED_PKGMGR:-auto}" 2>&1 || true
 
   if package::is_installed "$package_name"; then
     output::write "✅ \`$package_name\` installed"

--- a/scripts/package/src/package_managers/README.md
+++ b/scripts/package/src/package_managers/README.md
@@ -1,0 +1,12 @@
+## About adding new package managers
+
+Forbbiden names:
+* `recipe`
+* `recipes`
+* `auto`
+
+### Registry, recipe(s)
+If you plan to add any new package manager you must know that any package manager called `recipe` or `recipes` will not work because they are a valid aliases for `registry` package manager.
+
+### Auto
+Similar thing happen with keyword `auto` which is a keyword to say `package::install` and `package::uninstall` use any package manager that is not the `registry`.


### PR DESCRIPTION
* Removed non used private function `package::_uninstall`
* Added `auto` as package manager in `package::uninstall`, this option will ignore `registry` as package manager (recipes) and try to uninstall the given package with any available package manager.
* Removed `package::install_recipe_first` now same functionality will be available directly with `package::install`, you can force to use registry.