### PR TITLE
[Fix] Add to /etc/shells when installing

### DIFF
--- a/scripts/core/install
+++ b/scripts/core/install
@@ -68,7 +68,7 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && ! str::contains zsh "$SHELL" && platfor
       ! grep -q "^${zsh_shell_path}$" "/etc/shells" &&
       sudo -v
   then
-    echo "$zsh_shell_path" | sudo tee "/etc/shells" &> /dev/null
+    sudo bash -c "echo '$zsh_shell_path' | tee -a /etc/shells" &> /dev/null
   fi
 
   {

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -55,11 +55,11 @@ install_macos_custom() {
     # Adds brew zsh and bash to /etc/shells
     HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix)}"
     if [[ -d "$HOMEBREW_PREFIX" && -x "${HOMEBREW_PREFIX}/bin/zsh" ]] && ! grep -q "^${HOMEBREW_PREFIX}/bin/zsh$" "/etc/shells" && sudo -v; then
-      echo "${HOMEBREW_PREFIX}/bin/zsh" | sudo tee "/etc/shells" &> /dev/null
+      sudo bash -c "echo '${HOMEBREW_PREFIX}/bin/zsh' | tee -a /etc/shells &> /dev/null"
     fi
 
     if [[ -d "$HOMEBREW_PREFIX" && -x "${HOMEBREW_PREFIX}/bin/bash" ]] && ! grep -q "^${HOMEBREW_PREFIX}/bin/bash$" "/etc/shells" && sudo -v; then
-      echo "${HOMEBREW_PREFIX}/bin/bash" | sudo tee "/etc/shells" &> /dev/null
+      sudo bash -c "echo '${HOMEBREW_PREFIX}/bin/bash' | tee -a /etc/shells &> /dev/null"
     fi
 
     output::answer "Installing mas"


### PR DESCRIPTION
* Fixed issue that were replacing in `/etc/shells` instead of adding them because forgotten option `-a` when using tee command.