### PR TITLE
[Fix] installer installed packages

### DIFF
--- a/scripts/core/install
+++ b/scripts/core/install
@@ -18,7 +18,7 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
 fi
 
 # OS specific packages
-output::anser "Installing specific OS packages if not installed"
+output::answer "Installing specific OS packages if not installed"
 if platform::is_macos; then
   output::answer "🍎 Setting up macOS platform"
   install_macos_custom

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -9,6 +9,16 @@ dot::load_library "install.sh"
 export ZIM_HOME="${SLOTH_PATH:-${DOTLY_PATH:-}}/modules/zimfw"
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# Mandatory packages first
+script::depends_on docpars fzf
+
+# Packages that are necessary but not in CI env
+if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+  script::depends_on python-yq jq cargo-update
+fi
+
+# OS specific packages
+output::anser "Installing specific OS packages if not installed"
 if platform::is_macos; then
   output::answer "🍎 Setting up macOS platform"
   install_macos_custom
@@ -16,8 +26,6 @@ elif platform::is_linux; then
   output::answer "🐧 Setting up Linux Platform"
   install_linux_custom
 fi
-
-script::depends_on cargo cargo-update docpars zsh fzf python3 python-yq jq
 
 ##? Install dotly and setup dotfiles. By default use a interactive backup (backups are not done for core symlinks).
 ##?

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -28,7 +28,6 @@ install_macos_custom() {
 
   mkdir -p "$HOME/bin"
 
-  output::answer "Installing needed gnu packages"
   if platform::command_exists brew; then
     brew cleanup -s | log::file "Brew executing cleanup"
     brew cleanup --prune-prefix | log::file "Brew removing dead symlinks"
@@ -46,11 +45,12 @@ install_macos_custom() {
     fi
   fi
 
-  custom::install bash zsh coreutils findutils gnu-sed python3-pip
+  output::answer "Installing needed gnu packages"
+  custom::install coreutils findutils gnu-sed
 
   # To make CI Checks faster this packages are only installed if not CI
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-    custom::install gnutls gnu-tar gnu-which gawk grep make hyperfine docpars zsh fzf python-yq jq
+    custom::install gnutls gnu-tar gnu-which gawk grep make bash zsh bash-completion@2 zsh-completions python3-pip
 
     # Adds brew zsh and bash to /etc/shells
     HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix)}"
@@ -102,17 +102,21 @@ install_linux_custom() {
     output::write "  2. Make an issue telling your os and which package manager are you using."
     output::answer "${SLOTH_GITHUB_REPOSITORY_NEW_ISSUE_URL}"
     output::empty_line
-    output::anser "Continue with cargo"
-    custom::install cargo cargo-update docpars hyperfine
+
+    if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+      output::anser "Continue with cargo"
+      custom::install cargo cargo-update docpars hyperfine
+    fi
+
     return
   fi
 
   output::answer "Installing Linux Packages"
-  custom::install bash zsh hyperfine docpars python3-pip build-essential coreutils findutils
+  custom::install build-essential coreutils findutils
 
   # To make CI Checks faster this packages are only installed if not CI
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-    custom::install fzf python-yq jq
+    custom::install bash zsh python3-pip python-yq jq
 
     # Required packages output an error
     if ! package::is_installed "docpars" || ! package::is_installed "python3-pip" || ! package::is_installed "python-yq"; then

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -99,11 +99,10 @@ registry::command() {
 #"
 registry::install() {
   local -r recipe="${1:-}"
-  local -r command="install"
   [[ -z "$recipe" ]] && return 1
   shift
 
-  registry::command "$recipe" "${command}" "$@"
+  registry::command "$recipe" "install" "$@"
 }
 
 #;
@@ -115,11 +114,10 @@ registry::install() {
 #"
 registry::uninstall() {
   local -r recipe="${1:-}"
-  local -r command="uninstall"
   [[ -z "$recipe" ]] && return 1
   shift
 
-  registry::command "$recipe" "${command}" "$@"
+  registry::command "$recipe" "uninstall" "$@"
 }
 
 #;

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -94,28 +94,32 @@ registry::command() {
 # registry::install()
 # Install the given recipe
 # @param string recipe
+# @param any optional args
 # @return boolean
 #"
 registry::install() {
   local -r recipe="${1:-}"
   local -r command="install"
   [[ -z "$recipe" ]] && return 1
+  shift
 
-  registry::command "$recipe" "${command}"
+  registry::command "$recipe" "${command}" "$@"
 }
 
 #;
 # registry::uninstall()
 # Uninstall the given recipe
 # @param string recipe
+# @param any optional args
 # @return boolean
 #"
 registry::uninstall() {
   local -r recipe="${1:-}"
   local -r command="uninstall"
   [[ -z "$recipe" ]] && return 1
+  shift
 
-  registry::command "$recipe" "${command}"
+  registry::command "$recipe" "${command}" "$@"
 }
 
 #;

--- a/scripts/package/install
+++ b/scripts/package/install
@@ -8,15 +8,16 @@
 ##? Usage:
 ##?    add -v | --version
 ##?    add -h | --help
-##?    add [-s | --skip-recipe] [--pkgmgr <package_manager>] <packages_names>...
+##?    add [-f | --force] [-s | --skip-recipe] [--pkgmgr <package_manager>] <packages_names>...
 ##?
 ##? Options:
 ##?    -h --help         Show script help
 ##?    -v --version      Show script version
+##?    -f --force        Pass to install wrapper (function ::install) --force option
 ##?    -s --skip-recipe  Skip the receipe and force to use a package manager, this omit any recipe
 ##?    --pkgmgr          Force to use a package manager, for example: cargo
 ##?
-##? SCRIPT_VERSION 3.1.0
+##? SCRIPT_VERSION 3.2.0
 if ! ${DOTLY_INSTALLER:-false} && package::is_installed "docpars"; then
   docs::parse "$@"
   _all_args=("$@")
@@ -45,6 +46,10 @@ else
       --pkgmgr)
         package_manager="$2"
         shift 2
+        ;;
+      --force | -f)
+        force=true
+        shift
         ;;
       --version | -v)
         version=true
@@ -115,17 +120,24 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 # Check if package is installed
-package::is_installed "$package_name" && log::success "$package_name already installed" && exit 0
+! ${force:-false} && package::is_installed "$package_name" && log::success "$package_name already installed" && exit 0
+
+# if force give to install argument --force
+if ${force:-false}; then
+  install_args=("--force")
+else
+  install_args=()
+fi
 
 # If there is a recipe for the package use it
 if ! ${skip_recipe:-false} &&
   [[ -n "$(registry::recipe_exists "$package_name")" ]]; then
-  if registry::install "$package_name"; then
+  if registry::install "$package_name" "${install_args[@]}"; then
     output::write "✅ \`$package_name\` installed"
     exit 0
   fi
 else
-  package::install "$package_name" "${FORCED_PKGMGR:-}" 2>&1 || true
+  package::install "$package_name" "${FORCED_PKGMGR:-auto}" "${install_args[@]}" 2>&1 || true
 
   if package::is_installed "$package_name"; then
     output::write "✅ \`$package_name\` installed"

--- a/scripts/package/remove
+++ b/scripts/package/remove
@@ -10,18 +10,20 @@ set -euo pipefail
 uninstall_package_output() {
   [[ -z "${1:-}" ]] && return 1
   local -r package_name="$1"
+  shift
   if ! package::is_installed "$package_name"; then
     output::answer "Package \`$package_name\` is not installed"
   else
-    uninstall_package_force "$package_name"
+    uninstall_package_force "$package_name" "$@"
   fi
 }
 
 uninstall_package_force() {
   [[ -z "${1:-}" ]] && return 1
   local -r package_name="$1"
+  shift
 
-  if package::uninstall "$package_name" && ! package::is_installed "$package_name"; then
+  if package::uninstall "$package_name" "any" "$@" && ! package::is_installed "$package_name"; then
     output::answer "Package \`$package_name\` was uninstalled"
   else
     output::error "Package \`$package_name\` could not be uninstalled"
@@ -62,14 +64,14 @@ fi
 output_code=0
 if [[ ${#packages_names[@]} -eq 1 ]]; then
   if ${force:-false}; then
-    uninstall_package_force "${packages_names[*]}" || output_code=1
+    uninstall_package_force "${packages_names[*]}" --force || output_code=1
   else
     uninstall_package_output "${packages_names[*]}" || output_code=1
   fi
 else
   for package_name in "${packages_names[@]}"; do
     if ${force:-false}; then
-      uninstall_package_force "$package_name" || output_code=1
+      uninstall_package_force "$package_name" --force || output_code=1
     else
       uninstall_package_output "$package_name" || output_code=1
     fi

--- a/scripts/package/src/package_managers/cargo.sh
+++ b/scripts/package/src/package_managers/cargo.sh
@@ -29,7 +29,7 @@ cargo::is_installed() {
 
     return 0
   else
-    [[ -n "${1:-}" ]] && cargo::is_available && cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d ' ' | grep -q "${1:-}"
+    [[ -n "${1:-}" ]] && cargo::is_available && cargo install --list | grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | cut -f1 -d ' ' | grep -q "^$1$"
   fi
 }
 

--- a/scripts/package/src/recipes/bash.sh
+++ b/scripts/package/src/recipes/bash.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+bash::is_installed() {
+  if platform::is_macos; then
+    package::is_installed bash auto && return 0
+  else
+    platform::command_exists bash && return 0
+  fi
+
+  return 1
+}
+
+bash::install() {
+  if [[ $* == *"--force"* ]] && platform::command_exists brew && ! bash::is_installed; then
+    brew reinstall bash
+  else
+    package::install bash auto
+  fi
+
+  bash::is_installed || output::error "Could not be installed" && return 1
+  output::solution "Bash installed"
+}
+
+bash::uninstall() {
+  if platform::command_exists brew; then
+    brew uninstall --ignore-dependencies bash || true
+  else
+    package::uninstall bash auto
+  fi
+
+  bash::is_installed && output::error "Bash could not be installed" && return 1
+  output::solution "Bash uninstalled"
+}

--- a/scripts/package/src/recipes/cargo.sh
+++ b/scripts/package/src/recipes/cargo.sh
@@ -15,10 +15,6 @@ cargo::install() {
     rustup install stable
     rustup default stable
   fi
-
-  if platform::command_exists cargo; then
-    script::depends_on cargo-update
-  fi
 }
 
 cargo::is_installed() {

--- a/scripts/package/src/recipes/zsh.sh
+++ b/scripts/package/src/recipes/zsh.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+zsh::is_installed() {
+  if platform::is_macos; then
+    package::is_installed zsh auto && return 0
+  else
+    platform::command_exists zsh && return 0
+  fi
+
+  return 1
+}
+
+zsh::install() {
+  if [[ $* == *"--force"* ]] && platform::command_exists brew && ! zsh::is_installed; then
+    brew reinstall bash
+  else
+    package::install zsh auto
+  fi
+
+  zsh::is_installed || output::error "Could not be installed" && return 1
+  output::solution "Bash installed"
+}
+
+zsh::uninstall() {
+  if platform::command_exists brew; then
+    brew uninstall --ignore-dependencies bash || true
+  else
+    package::uninstall bash auto
+  fi
+
+  zsh::is_installed && output::error "Bash could not be installed" && return 1
+  output::solution "Bash uninstalled"
+}

--- a/scripts/package/which
+++ b/scripts/package/which
@@ -19,7 +19,7 @@ which_package_output() {
     output::error "Package named \`${package_name}\` was not installed with any package manager"
     return 1
   else
-    output::solution "Package named \`${package_name}\` was installed with \`$package_manager\`"
+    output::answer "Package named \`${package_name}\` was installed with \`$package_manager\`"
   fi
 }
 

--- a/scripts/symlinks/apply
+++ b/scripts/symlinks/apply
@@ -144,7 +144,7 @@ else
   done
 fi
 
-SCRIPT_NAME="sloth symlinks apply"
+SCRIPT_NAME="dot symlinks apply"
 
 # Print name and version
 if ${version:-false}; then
@@ -153,6 +153,11 @@ if ${version:-false}; then
 elif ${help:-false}; then
   grep "##?" "$(dot::get_full_script_path)"
   exit
+fi
+
+# Possible backups are not done in CI
+if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+  script::depends_on python-yq jq
 fi
 
 # Vars to be used

--- a/scripts/symlinks/apply
+++ b/scripts/symlinks/apply
@@ -87,6 +87,10 @@ select_yaml_files_in_path() {
 ##? SCRIPT_VERSION "2.1.0"
 if ! ${DOTLY_INSTALLER:-false}; then
   docs::parse "$@"
+
+  if ${backup:-} || ${interactive_backup:-}; then
+    script::depends_on python-yq
+  fi
 else
   version=false
   help=false
@@ -117,10 +121,12 @@ else
         ;;
       --backup)
         { $interactive_backup || $ignore_backup; } && output::error "Error you can not use \`--backup\` with \`--interactive-backup\` or \`--ignore-backup\`" && exit 4
+        script::depends_on python-yq jq
         backup=true
         ;;
       --interactive-backup)
         { $backup || $ignore_backup; } && output::error "Error you can not use \`--interactive-backup\` with \`--backup\` or \`--ignore-backup\`" && exit 4
+        script::depends_on python-yq jq
         interactive_backup=true
         shift
         ;;
@@ -153,11 +159,6 @@ if ${version:-false}; then
 elif ${help:-false}; then
   grep "##?" "$(dot::get_full_script_path)"
   exit
-fi
-
-# Possible backups are not done in CI
-if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-  script::depends_on python-yq jq
 fi
 
 # Vars to be used


### PR DESCRIPTION
## Changes
* Changes in `dot core install` and `install.sh` when to install some packages to try to make CI faster.
* Fixed dependencies in `dot symlinks apply` to only when `python-yq` is necessary
* Added some internal possibilities with package managers. Now `::install` and `::uninstall` functions can receive arguments even when you do not know which package manager you want to use.
* Fixed message colors when using `dot package which`
* Added `bash` recipe
* Added `zsh` recipe