### PR TITLE
[Fix] Improve Command Line Tools recipe

### DIFF
--- a/scripts/package/src/recipes/clt.sh
+++ b/scripts/package/src/recipes/clt.sh
@@ -37,8 +37,10 @@ clt::install() {
   if ! clt::is_installed; then
     /usr/bin/xcode-select --install
     if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-      output::write "Press any key when installation is completed..."
-      read -r -n 1
+      until xcode-select --print-path &> /dev/null; do
+        output::answer "Waiting for Command Line tools to be installed... Check again in 10 secs"
+        sleep 10
+      done
     fi
   fi
 

--- a/scripts/package/src/recipes/clt.sh
+++ b/scripts/package/src/recipes/clt.sh
@@ -59,7 +59,7 @@ clt::install() {
 }
 
 clt::is_installed() {
-  platform::is_macos && command -vp xcode-select &>/dev/null && xpath=$(command -p xcode-select --print-path) && test -d "${xpath}" && test -x "${xpath}"
+  platform::is_macos && command -vp xcode-select &> /dev/null && xpath=$(command -p xcode-select --print-path) && test -d "${xpath}" && test -x "${xpath}"
 }
 
 clt::uninstall() {


### PR DESCRIPTION
* Remove using complete paths in favour of `command -p` or `command -vp`.
* Added wait for CLT to be installed when using graphical installation.