### PR TITLE
[Feature] dot in /usr/local/bin

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
-#shellcheck disable=2016
+#shellcheck disable=SC2128,SC2016
 
 set -o pipefail
+
+# In Linux we can do this with readlink -f but will fail in macOS and BSD OS
+if [[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]]; then
+  dot_path="$BASH_SOURCE"
+  until [[ ! -L $dot_path ]]; do
+    dot_path="$(readlink "$dot_path")"
+  done
+  SLOTH_PATH="$(dirname "$(dirname "$dot_path")")"
+  DOTLY_PATH="$SLOTH_PATH"
+
+  if [[ ! -d "$SLOTH_PATH" || ! -x "${SLOTH_PATH}/bin/dot" ]]; then
+    echo "Error: Could not find the SLOTH source code."
+    exit 1
+  fi
+  export SLOTH_PATH DOTLY_PATH
+fi
 
 #shellcheck disable=SC1091
 . "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
@@ -42,8 +58,8 @@ fi
 
 # This script version
 if [[ "$1" == "-v" || "$1" == "--version" ]]; then
-  SCRIPT_VERSION="$(dot::parse_script_version "$0")"
-  SCRIPT_NAME="$(basename "$0")"
+  SCRIPT_VERSION="$(dot::parse_script_version "$BASH_SOURCE")"
+  SCRIPT_NAME="$(basename "$BASH_SOURCE")"
   if [[ -n "${SCRIPT_VERSION}" ]]; then
     output::write "${SCRIPT_NAME}"
     output::write "\t\`v${SCRIPT_VERSION}\`"

--- a/bin/dot
+++ b/bin/dot
@@ -24,8 +24,8 @@ SLOTH_SCRIPT_BASE_NAME="sloth"
 ##?    dot
 ##?
 ##? Arguments:
-##?    context  Is the subfolder in "\${DOTFILES_PATH}/scripts/" or "\${DOTLY_PATH:-\${SLOTH_PATH:-${DOTLY_PATH:-}}}/scripts"
-##?    script   Is the script in "\${DOTFILE${SLOTH_PATH:-S_PATH}/scr}ipts/<context>" or "\${DOTLY_PATH:-\${SLOTH_PATH:-${DOTLY_PATH:-}}}/scripts/<conte${SLOTH_PATH:-xt>"
+##?    context  Is the subfolder in "\${DOTFILES_PATH}/scripts/" or "\${SLOTH_PATH:-\${DOTLY_PATH:-}}/scripts"
+##?    script   Is the script in "\${DOTFILES_PATH}/scripts/<context>" or "\${SLOTH_PATH:-\${DOTLY_PATH:-}}/scripts/<context>"
 ##?
 #}#? Options:
 ##?    -h --help     Gives help to the user

--- a/bin/dot
+++ b/bin/dot
@@ -16,7 +16,11 @@ if [[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}
     echo "Error: Could not find the SLOTH source code."
     exit 1
   fi
-  export SLOTH_PATH DOTLY_PATH
+
+  if [[ -z "${DOTFILES_PATH:-}" && -d "${HOME}/.dotfiles/scripts" ]]; then
+    DOTFILES_PATH="$HOME/.dotfiles"
+  fi
+  export SLOTH_PATH DOTLY_PATH DOTFILES_PATH
 fi
 
 #shellcheck disable=SC1091

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -108,6 +108,10 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && platform::command_exists zsh; then
   } || output::error '❌ Error reloading completions'
 fi
 
+output::answer "Linking dot command for all users in \`/usr/local/bin\`"
+ln -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" /usr/local/bin/dot
+[[ -x "/usr/local/bin/dot" ]] || output::error "\`dot\` command could not be linked"
+
 output::answer "Executing custom restoration scripts"
 install_scripts_path="${DOTFILES_PATH}/restoration_scripts"
 if [ -d "$install_scripts_path" ]; then

--- a/scripts/core/src/dot.sh
+++ b/scripts/core/src/dot.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#shellcheck disable=SC2128
 
 [[ -z "${SCRIPT_LOADED_LIBS[*]:-}" ]] && SCRIPT_LOADED_LIBS=()
 

--- a/scripts/core/src/platform.sh
+++ b/scripts/core/src/platform.sh
@@ -74,12 +74,16 @@ platform::is_linux() {
   [[ $SLOTH_OS == *"Linux"* ]]
 }
 
+platform::is_windows() {
+  [[ $SLOTH_OS == "Windows"* || $SLOTH_OS == "MINGW64"* || $SLOTH_OS == "CYGWIN_NT"* || $SLOTH_OS == "MS-DOS" || $SLOTH_OS == "MSYS"* || $SLOTH_OS == "Wine"* || $SLOTH_OS == "UWIN"* ]]
+}
+
 platform::is_wsl() {
   grep -qEi "(Microsoft|WSL|microsoft)" /proc/version &> /dev/null || grep -q -F 'Microsoft' /proc/sys/kernel/osrelease
 }
 
 platform::is_bsd() {
-  [[ $SLOTH_OS == *"BSD"* ]]
+  platform::is_macos || [[ $SLOTH_OS == *"BSD"* || $SLOTH_OS == "DragonFly" || $SLOTH_OS == "Minix" ]]
 }
 
 platform::os() {


### PR DESCRIPTION
## Changelog
* Install `dot` in `/usr/local/bin` path.
* Fix documentation for `dot` command
* Improved `platform::is_bsd`
* Added `platform::is_windows`

## Description
Probably this will change in future because I think currently this is not the best way to install .Sloth/Dotly. Probably in near future will be available in package managers or the installer will make a real install of .Sloth and not be as a submodule.

With this you can run .Sloth in a non interactive shell which is very interesting to run dot core scripts like `dot package update_all`.