### PR TITLE
[Fix] non login dot fails

### DIFF
--- a/_raycast/dot.sh
+++ b/_raycast/dot.sh
@@ -11,12 +11,16 @@
 # @raycast.argument2 { "type": "text", "placeholder": "Script", "optional": false }
 # @raycast.argument3 { "type": "text", "placeholder": "Arguments for .Sloth script", "optional": true }
 # @raycast.packageName Productivity
-# @raycast.needsConfirmation true
+# @raycast.needsConfirmation false
 
 # Documentation:
 # @raycast.description Executes lazy .Sloth shell scripts
 # @raycast.author Gabriel Trabanco
 # @raycast.authorURL https://github.com/gtrabanco
+
+# For some scripts we need the user enviroment
+#shellcheck disable=SC1091
+[[ -f "${HOME}/.bashrc" ]] && . "${HOME}/.bashrc"
 
 context="${1:-}"
 script="${2:-}"

--- a/_raycast/sdot.sh
+++ b/_raycast/sdot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Same functionality as sdot command. dot without enviroment variables.
+# @raycast.mode fullOutput
+
+# Optional parameters:
+# @raycast.icon ⚫️
+# @raycast.argument1 { "type": "text", "placeholder": "Context", "optional": false }
+# @raycast.argument2 { "type": "text", "placeholder": "Script", "optional": false }
+# @raycast.argument3 { "type": "text", "placeholder": "Arguments for .Sloth script", "optional": true }
+# @raycast.packageName Productivity
+# @raycast.needsConfirmation false
+
+# Documentation:
+# @raycast.description Executes lazy .Sloth shell scripts
+# @raycast.author Gabriel Trabanco
+# @raycast.authorURL https://github.com/gtrabanco
+
+context="${1:-}"
+script="${2:-}"
+arg="${3:-}"
+
+if command -v dot &> /dev/null; then
+  dot "$context" "$script" $arg | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+else
+  echo "Error: dot is not installed for not login shell. Execute \`dot core install\` again"
+  exit 1
+fi

--- a/_raycast/update-all.sh
+++ b/_raycast/update-all.sh
@@ -3,7 +3,7 @@
 # Required parameters:
 # @raycast.schemaVersion 1
 # @raycast.title Update All System Packages
-# @raycast.mode fullOutput
+# @raycast.mode inline
 
 # Optional parameters:
 # @raycast.icon ♻️
@@ -15,6 +15,10 @@
 # @raycast.description Update all applications of all package managers that are supported by .Sloth
 # @raycast.author Gabriel Trabanco
 # @raycast.authorURL https://github.com/gtrabanco
+
+# We need user variables to update correct user packages
+#shellcheck disable=SC1091
+[[ -f "${HOME}/.bashrc" ]] && . "${HOME}/.bashrc"
 
 if command -v dot &> /dev/null; then
   if [[ -n "${1:-}" && $1 != "all" ]]; then

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -9,14 +9,6 @@ dot::load_library "install.sh"
 export ZIM_HOME="${SLOTH_PATH:-${DOTLY_PATH:-}}/modules/zimfw"
 export PATH="$HOME/.cargo/bin:$PATH"
 
-# Mandatory packages first
-script::depends_on clt curl git docpars fzf
-
-# Packages that are necessary but not in CI env
-if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-  script::depends_on python-yq jq cargo-update
-fi
-
 # OS specific packages
 output::answer "Installing specific OS packages if not installed"
 if platform::is_macos; then
@@ -25,6 +17,14 @@ if platform::is_macos; then
 elif platform::is_linux; then
   output::answer "🐧 Setting up Linux Platform"
   install_linux_custom
+fi
+
+# Mandatory packages
+script::depends_on docpars
+
+# Packages that are necessary but not in CI env
+if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
+  script::depends_on fzf python-yq jq cargo-update
 fi
 
 ##? Install dotly and setup dotfiles. By default use a interactive backup (backups are not done for core symlinks).

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -63,7 +63,12 @@ else
   $bk && output::yesno "Do you want to be asked for every file" || symlinks_args=(--backup)
   ! $bk && symlinks_args=(--ignore-backup)
 fi
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply "${symlinks_args[@]}" --continue-on-error --after-core | log::file "Applying symlinks"
+"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply "${symlinks_args[@]}" --continue-on-error --after-core 2>&1 | log::file "Applying symlinks"
+if $?; then
+  output::error "All symlinks were applied with errors. Use \`dot self debug\` to see what's wrong"
+else
+  output::solution "Symlinks applied"
+fi
 touch "$HOME/.z"
 unset symlinks_args bk
 

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -10,7 +10,7 @@ export ZIM_HOME="${SLOTH_PATH:-${DOTLY_PATH:-}}/modules/zimfw"
 export PATH="$HOME/.cargo/bin:$PATH"
 
 # Mandatory packages first
-script::depends_on docpars fzf
+script::depends_on clt curl git docpars fzf
 
 # Packages that are necessary but not in CI env
 if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then

--- a/scripts/core/src/install.sh
+++ b/scripts/core/src/install.sh
@@ -23,6 +23,7 @@ install_macos_custom() {
       export CI=1
     fi
 
+    registry::install "clt"
     registry::install "brew"
   fi
 
@@ -46,11 +47,14 @@ install_macos_custom() {
   fi
 
   output::answer "Installing needed gnu packages"
-  custom::install coreutils findutils gnu-sed
+  custom::install clt curl git coreutils findutils gnu-sed
 
   # To make CI Checks faster this packages are only installed if not CI
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
-    custom::install gnutls gnu-tar gnu-which gawk grep make bash zsh bash-completion@2 zsh-completions python3-pip
+    custom::install gnutls gnu-tar gnu-which gawk grep
+
+    output::answer "Installing other needed packages"
+    custom::install make bash zsh bash-completion@2 zsh-completions python3-pip
 
     # Adds brew zsh and bash to /etc/shells
     HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix)}"
@@ -112,7 +116,7 @@ install_linux_custom() {
   fi
 
   output::answer "Installing Linux Packages"
-  custom::install build-essential coreutils findutils
+  custom::install curl git build-essential coreutils findutils
 
   # To make CI Checks faster this packages are only installed if not CI
   if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then


### PR DESCRIPTION
* Fix that Raycast scripts were failing because the user env vars were not being loaded.
* Added Raycast `sdot` to avoid loading `.bashrc` file for scripts that does not need env vars (those that work in non login shell).
* Added `Command Line Tools`, `git` and `curl` as dependency in all systems in `dot core install` so now you can execute .Sloth from whatever you have it downloaded and generate your own dotfiles. If you do this you must init your dotfiles as repository if you want to make them a repository.