### PR TITLE
[Fix] recipes

### DIFF
--- a/scripts/package/src/package_managers/brew.sh
+++ b/scripts/package/src/package_managers/brew.sh
@@ -14,7 +14,11 @@ brew::install() {
     *) package="${1:-}" ;;
   esac
 
-  brew install "$package"
+  if [[ $* == *--force* ]]; then
+    brew install --force "$package"
+  else
+    brew install "$package"
+  fi
 }
 
 brew::uninstall() {

--- a/scripts/package/src/recipes/bash.sh
+++ b/scripts/package/src/recipes/bash.sh
@@ -11,11 +11,7 @@ bash::is_installed() {
 }
 
 bash::install() {
-  if [[ $* == *"--force"* ]] && platform::command_exists brew && ! bash::is_installed; then
-    brew reinstall bash
-  else
-    package::install bash auto
-  fi
+  package::install bash auto "${1:-}"
 
   bash::is_installed || output::error "Could not be installed" && return 1
   output::solution "Bash installed"
@@ -28,6 +24,6 @@ bash::uninstall() {
     package::uninstall bash auto
   fi
 
-  bash::is_installed && output::error "Bash could not be installed" && return 1
+  bash::is_installed && output::error "Bash could not be uninstalled" && return 1
   output::solution "Bash uninstalled"
 }

--- a/scripts/package/src/recipes/cargo-update.sh
+++ b/scripts/package/src/recipes/cargo-update.sh
@@ -4,7 +4,11 @@ cargo-update::install() {
   script::depends_on cargo
 
   if platform::command_exists cargo; then
-    cargo install cargo-update
+    if [[ -n "${1:-}" && "${1}" == "--force" ]]; then
+      cargo install --force cargo-update
+    else
+      cargo install cargo-update
+    fi
   else
     return 1
   fi

--- a/scripts/package/src/recipes/cargo.sh
+++ b/scripts/package/src/recipes/cargo.sh
@@ -2,7 +2,7 @@
 
 cargo::install() {
   if ! platform::is_macos; then
-    package::install build-essential
+    package::install build-essential auto
   fi
 
   curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path 2>&1 | log::file "Installing rust from sources"

--- a/scripts/package/src/recipes/curl.sh
+++ b/scripts/package/src/recipes/curl.sh
@@ -5,13 +5,9 @@ curl::install() {
     script::depends_on build-essential
   fi
 
-  if command -v package::install &> /dev/null; then
-    package::install "curl"
-  elif [[ -x "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" ]]; then
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add curl
-  fi
+  package::install "curl" "auto" "${1:-}"
 
-  cur::is_installed
+  curl::is_installed
 }
 
 curl::is_installed() {

--- a/scripts/package/src/recipes/deno.sh
+++ b/scripts/package/src/recipes/deno.sh
@@ -12,10 +12,10 @@ deno::install() {
 
   if
     ! deno::is_installed &&
-    {
-      ! platform::command_exists unzip ||
-      ! platform::command_exists curl
-    }
+      {
+        ! platform::command_exists unzip ||
+          ! platform::command_exists curl
+      }
   then
     script::depends_on curl unzip
 

--- a/scripts/package/src/recipes/deno.sh
+++ b/scripts/package/src/recipes/deno.sh
@@ -1,25 +1,35 @@
 #!/usr/bin/env bash
 
 deno::install() {
-  if platform::command_exists cargo; then
-    cargo install deno
-  else
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add --skip-recipe deno
+  package::install deno auto "${1:-}"
+  package::is_installed deno auto &&
+    output::solution "Deno installed" &&
+    return 0
+
+  if [[ "${1:-}" = "--force" ]]; then
+    output::answer "\`--force\` option is ignored with deno when installing from source"
   fi
 
-  if ! platform::command_exists deno &&
-    ! platform::command_exists curl; then
+  if
+    ! deno::is_installed &&
+    {
+      ! platform::command_exists unzip ||
+      ! platform::command_exists curl
+    }
+  then
     script::depends_on curl unzip
-  fi
 
-  if platform::command_exists curl; then
-    curl -fsSL https://deno.land/x/install/install.sh | sh
+    if platform::command_exists curl; then
+      curl -fsSL https://deno.land/x/install/install.sh | sh
+    fi
   fi
 
   if platform::command_exists deno; then
+    output::solution "Deno installed"
     return
   fi
 
+  output::error "Deno could not be installed"
   return 1
 }
 

--- a/scripts/package/src/recipes/git-delta.sh
+++ b/scripts/package/src/recipes/git-delta.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 git-delta::install() {
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add git-delta --skip-recipe
+  package::install git-delta auto
 }
 
 git-delta::is_installed() {

--- a/scripts/package/src/recipes/python-yq.sh
+++ b/scripts/package/src/recipes/python-yq.sh
@@ -9,7 +9,7 @@ python-yq::install() {
 
     elif
       platform::command_exists python3 &&
-      python3 -c "import pip; print(pip.__version__)" &> /dev/null
+        python3 -c "import pip; print(pip.__version__)" &> /dev/null
     then
       python3 -m pip install --ignore-installed --user --no-cache-dir yq
     else

--- a/scripts/package/src/recipes/python-yq.sh
+++ b/scripts/package/src/recipes/python-yq.sh
@@ -3,8 +3,27 @@
 python-yq::install() {
   script::depends_on python3-pip
 
+  if [[ -n "${1:-}" && $1 == "--force" ]] && python-yq::is_installed; then
+    if platform::command_exists brew; then
+      brew reinstall python-yq
+
+    elif
+      platform::command_exists python3 &&
+      python3 -c "import pip; print(pip.__version__)" &> /dev/null
+    then
+      python3 -m pip install --ignore-installed --user --no-cache-dir yq
+    else
+      output::error "Unable to locate any valid package manager to force install python-yq"
+      return 1
+    fi
+
+    python-yq::is_installed && return 0
+
+  fi
+
   if
-    platform::command_exists brew &&
+    ! python-yq::is_installed &&
+      platform::command_exists brew &&
       brew install python-yq &&
       python-yq::is_installed
   then
@@ -12,8 +31,9 @@ python-yq::install() {
   fi
 
   if
-    platform::command_exists pip3 &&
-      pip3 install yq &&
+    ! python-yq::is_installed &&
+      platform::command_exists pip3 &&
+      python3 -m pip install --user --no-cache-dir yq &&
       python-yq::is_installed
   then
     output::solution "yq installed!"

--- a/scripts/package/src/recipes/tldr.sh
+++ b/scripts/package/src/recipes/tldr.sh
@@ -5,7 +5,7 @@ tldr::is_installed() {
 }
 
 tldr::install() {
-  ! tldr::is_installed && package::install tldr
+  package::install tldr auto "${1:-}"
 }
 
 tldr::is_outdated() {


### PR DESCRIPTION
* Fix all recipes to use new way of `package::install` instead of calling `dot package add` with `--skip-recipe` argument
* Added force option in `brew` package manager when try to force an installation.