### PR TITLE
[Fix] git_extended core library

### DIFF
--- a/scripts/core/src/git_extended.sh
+++ b/scripts/core/src/git_extended.sh
@@ -93,7 +93,7 @@ git::is_valid_commit() {
 # @return boolean
 #"
 git::remote_branch_exists() {
-  local remote_branch
+  local remote branch
 
   if [[ $# -gt 1 ]]; then
     remote="$1"


### PR DESCRIPTION
* "Fixed misspelling of variable names when defining local use of the variables in `git::remote_branch_exists` function.