### PR TITLE
[Fix] Require elevation

### DIFF
--- a/scripts/package/src/package_managers/apt.sh
+++ b/scripts/package/src/package_managers/apt.sh
@@ -2,6 +2,10 @@
 
 apt_title='@ APT'
 
+apt::require_sudo_elevation() {
+  return 0
+}
+
 apt::is_available() {
   platform::command_exists apt-get && platform::command_exists apt-cache && platform::command_exists dpkg
 }


### PR DESCRIPTION
<!---
Please use English as main language
Provide a general summary of your changes in the Title above
Use prefix by type of change:
- [Feature]
- [Fix]
- [Doc]
Also add [HELP NEEDED] before if you need some∩ help.
Add also [WIP] before every other prefix if you have task to do or you have proposed task (because work in a team or you desire some help).
-->

## Humman Changelog
<!--
Provide a human changelog (does not need to be as your commits) with the changes you made, example:
- Fix: Issue #83
- Feature: Added new cool stuff...
--->

## Description
Provide a more elegant way to use package manager that require permission elevation through `sudo` to be executed

## Related Issue
<!--- If suggesting a new feature or change and was discussed it firs. Add here the link to the issue or discussion. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Probably user will be asked once to write the password but this should happen at the beginning of the script and not when the command is executed. Why? Because we want more unattended scripts.

## Screenshots (if appropriate):

## Tasks
<!---
Only for large PRs and when you have multiple stuff to do. Use this only if this is a WIP (Work In Progress) PR.
Delete if your PR is ready when you create the PR.
 --->
- [ ] Apply linter `dot core lint` && `dot core lint --patch`
- [ ] Check shellcheks that makes script to not pass the checks `dot core static_analysis`
- [ ] Apply a way to check if a function of the package manager requires a sudo and if yes, ask sudo password at the begining.
- [ ] Do all required changes in package manager to make this work.

 ## Other
<!--- If you want to add something add it here --->

This should also help to make easier and more intuitive updates that avoid update errors or non update system packages with `gem` package manager. See related issue #130