### PR TITLE
[Fix] dot link can be ignored

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -72,7 +72,7 @@ if [[ "$1" == "-v" || "$1" == "--version" ]]; then
 fi
 
 if ! git::is_in_repo -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"; then
-  output::error "Error: .Sloth needs to execute \`dot core install --ignore-symlinks\` previously to be used."
+  output::error "Error: .Sloth needs to execute \`dot core install --only-initilize-sloth\` previously to be used."
   output::answer "This will install some tools in your system and also init current .Sloth folder as repository"
   exit 1
 fi

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -34,10 +34,22 @@ has_sudo() {
   command -p sudo -n -v &> /dev/null
 }
 
+initilize_sloth_if_necessary() {
+  if ! git::is_in_repo -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"; then
+    output::answer "Initilizing .Sloth as repository"
+    sloth_update::sloth_repository_set_ready | log::file "Initilizing .Sloth as repository" || true
+    output::empty_line
+  fi
+
+  output::answer "Updating .Sloth submodules"
+  git::git -C "${SLOTH_PATH:-${DOTLY_PATH:-}}" submodule update --init --recursive 2>&1 | log::file "Update .Sloth submodules" || true
+  output::empty_line
+}
+
 ##? Install dotly and setup dotfiles. By default use a interactive backup (backups are not done for core symlinks).
 ##?
 ##? Usage:
-##?    install [[-n | --never-backup] | [-b |--always-backup] | [--ignore-symlinks]] [--ignore-restoration] [--without-link]
+##?    install [[-n | --never-backup] | [-b |--always-backup] | [--ignore-symlinks]] [--ignore-restoration]
 ##?
 ##? Options:
 ##?    -h --help                Prints this help
@@ -46,9 +58,9 @@ has_sudo() {
 ##?    -i --interactive-backup  Interactive backup of user symlinks asking for every existing symlink before to be applied (default)
 ##?    --ignore-symlinks        Ignore apply symlinks. Useful for very custom installations
 ##?    --ignore-restoration     Ignore user restoration scripts
-##?    --without-link           Ignore link dot command in /usr/local/bin
+##?    --only-initilize-sloth   Executes only the .Sloth initilization if necessary
 ##?
-##? SCRIPT_VERSION "3.0.0"
+##? SCRIPT_VERSION "3.1.0"
 if ! ${DOTLY_INSTALLER:-false} && package::is_installed "docpars"; then
   docs::parse "$@"
 else
@@ -59,7 +71,7 @@ else
   ignore_backup=false
   ignore_symlinks=false
   ignore_restoration=false
-  without_link=false
+  only_initilize_sloth=false
   while [[ $# -gt 0 ]]; do
     case "${1:-}" in
       --version | -v)
@@ -94,8 +106,8 @@ else
         ignore_restoration=true
         shift
         ;;
-      --without-link)
-        without_link=true
+      --only-initilize-sloth)
+        only_initilize_sloth=true
         shift
         ;;
       *)
@@ -113,6 +125,9 @@ if ${version:-false}; then
   exit
 elif ${help:-false}; then
   grep "##?" "$(dot::get_full_script_path)" | cut -c 5-
+  exit
+elif ${only_initilize_sloth:-false}; then
+  initilize_sloth_if_necessary
   exit
 fi
 
@@ -217,6 +232,9 @@ export SETUP_ZSH_AS_DEFAULT_SHELL
 export ZIM_HOME="${SLOTH_PATH:-${DOTLY_PATH:-}}/modules/zimfw"
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# Initilize .Sloth only if necessary
+initilize_sloth_if_necessary
+
 # OS specific packages
 output::answer "Installing specific OS packages if not installed"
 if platform::is_macos; then
@@ -235,16 +253,6 @@ script::depends_on docpars
 if [[ "${DOTLY_ENV:-PROD}" != "CI" ]]; then
   script::depends_on fzf python-yq jq cargo-update
 fi
-
-if ! git::is_in_repo -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"; then
-  output::answer "Initilizing .Sloth as repository"
-  sloth_update::sloth_repository_set_ready | log::file "Initilizing .Sloth as repository" || true
-  output::empty_line
-fi
-
-output::answer "Updating .Sloth submodules"
-git::git -C "${SLOTH_PATH:-${DOTLY_PATH:-}}" submodule update --init --recursive 2>&1 | log::file "Update .Sloth submodules" || true
-output::empty_line
 
 if [[ -n "$DOTFILES_PATH" ]]; then
   output::answer "Creating dotfiles structure"
@@ -321,27 +329,25 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && platform::command_exists zsh; then
   output::empty_line
 fi
 
-if ! ${without_link:-false}; then
-  output::answer "Linking dot command for all users in \`/usr/local/bin\`"
-  ln -f -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" /usr/local/bin/dot
-  [[ -x "/usr/local/bin/dot" ]] || output::error "\`dot\` command could not be linked"
-  output::empty_line
+output::answer "Linking dot command for all users in \`/usr/local/bin\`"
+ln -f -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" /usr/local/bin/dot
+[[ -x "/usr/local/bin/dot" ]] || output::error "\`dot\` command could not be linked"
+output::empty_line
 
-  if ! ${ignore_restoration:-false} && ! ${IGNORE_RESTORATION:-false}; then
-    output::answer "Executing custom restoration scripts"
-    install_scripts_path="${DOTFILES_PATH}/restoration_scripts"
-    if [ -d "$install_scripts_path" ]; then
-      find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |
-        sort |
-        while read -r install_script; do
-          #shellcheck disable=SC1090
-          {
-            [[ -x "$install_script" ]] && . "$install_script" | log::file "Executing afterinstall: $(basename "$install_script")"
-          } || {
-            output::error "Install script error in \`$(basename "$install_script")\`"
-          }
-        done
-    fi
+if ! ${ignore_restoration:-false} && ! ${IGNORE_RESTORATION:-false}; then
+  output::answer "Executing custom restoration scripts"
+  install_scripts_path="${DOTFILES_PATH}/restoration_scripts"
+  if [ -d "$install_scripts_path" ]; then
+    find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |
+      sort |
+      while read -r install_script; do
+        #shellcheck disable=SC1090
+        {
+          [[ -x "$install_script" ]] && . "$install_script" | log::file "Executing afterinstall: $(basename "$install_script")"
+        } || {
+          output::error "Install script error in \`$(basename "$install_script")\`"
+        }
+      done
   fi
 fi
 

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -37,7 +37,7 @@ has_sudo() {
 ##? Install dotly and setup dotfiles. By default use a interactive backup (backups are not done for core symlinks).
 ##?
 ##? Usage:
-##?    install [[-n | --never-backup] | [-b |--always-backup] | [--ignore-symlinks]] [--ignore-restoration]
+##?    install [[-n | --never-backup] | [-b |--always-backup] | [--ignore-symlinks]] [--ignore-restoration] [--without-link]
 ##?
 ##? Options:
 ##?    -h --help                Prints this help
@@ -46,6 +46,7 @@ has_sudo() {
 ##?    -i --interactive-backup  Interactive backup of user symlinks asking for every existing symlink before to be applied (default)
 ##?    --ignore-symlinks        Ignore apply symlinks. Useful for very custom installations
 ##?    --ignore-restoration     Ignore user restoration scripts
+##?    --without-link           Ignore link dot command in /usr/local/bin
 ##?
 ##? SCRIPT_VERSION "3.0.0"
 if ! ${DOTLY_INSTALLER:-false} && package::is_installed "docpars"; then
@@ -58,6 +59,7 @@ else
   ignore_backup=false
   ignore_symlinks=false
   ignore_restoration=false
+  without_link=false
   while [[ $# -gt 0 ]]; do
     case "${1:-}" in
       --version | -v)
@@ -90,6 +92,10 @@ else
         ;;
       --ignore-restoration)
         ignore_restoration=true
+        shift
+        ;;
+      --without-link)
+        without_link=true
         shift
         ;;
       *)
@@ -315,25 +321,27 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && platform::command_exists zsh; then
   output::empty_line
 fi
 
-output::answer "Linking dot command for all users in \`/usr/local/bin\`"
-ln -f -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" /usr/local/bin/dot
-[[ -x "/usr/local/bin/dot" ]] || output::error "\`dot\` command could not be linked"
-output::empty_line
+if ! ${without_link:-false}; then
+  output::answer "Linking dot command for all users in \`/usr/local/bin\`"
+  ln -f -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" /usr/local/bin/dot
+  [[ -x "/usr/local/bin/dot" ]] || output::error "\`dot\` command could not be linked"
+  output::empty_line
 
-if ! ${ignore_restoration:-false} && ! ${IGNORE_RESTORATION:-false}; then
-  output::answer "Executing custom restoration scripts"
-  install_scripts_path="${DOTFILES_PATH}/restoration_scripts"
-  if [ -d "$install_scripts_path" ]; then
-    find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |
-      sort |
-      while read -r install_script; do
-        #shellcheck disable=SC1090
-        {
-          [[ -x "$install_script" ]] && . "$install_script" | log::file "Executing afterinstall: $(basename "$install_script")"
-        } || {
-          output::error "Install script error in \`$(basename "$install_script")\`"
-        }
-      done
+  if ! ${ignore_restoration:-false} && ! ${IGNORE_RESTORATION:-false}; then
+    output::answer "Executing custom restoration scripts"
+    install_scripts_path="${DOTFILES_PATH}/restoration_scripts"
+    if [ -d "$install_scripts_path" ]; then
+      find "$install_scripts_path" -mindepth 1 -maxdepth 1 -type l,f -name '*.sh' |
+        sort |
+        while read -r install_script; do
+          #shellcheck disable=SC1090
+          {
+            [[ -x "$install_script" ]] && . "$install_script" | log::file "Executing afterinstall: $(basename "$install_script")"
+          } || {
+            output::error "Install script error in \`$(basename "$install_script")\`"
+          }
+        done
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Humman Changelog
- Added `--without-link` in `dot core install`. So now the link of dot command in `/usr/local/bin` can be avoided.
- Added `--only-initilize-sloth` in `dot core install`. This executes only the initialisation of .Sloth installation as repository and download all submodules that are dependencies of .Sloth.

## Description
By using `--without-link` the step that creates the symbolic link to `dot` in `/usr/local/bin` is avoided.

## Motivation and Context
This was added to be able only link `dot` with brew when use brew to install .Sloth as standalone tool.

## Tasks
<!---
Only for large PRs and when you have multiple stuff to do. Use this only if this is a WIP (Work In Progress) PR.
Delete if your PR is ready when you create the PR.
 --->
- [x] Apply linter `dot core lint` && `dot core lint --patch`
- [x] Check shellcheks that makes script to not pass the checks `dot core static_analysis`

