### PR TITLE
[Feature] Added makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Default target
+default: install
+
+SLOTH_PATH=${SLOTH_PATH:-$(dirname $BASH_SOURCE)}
+
+install:
+	@echo "Initilise .Sloth installation as repository..."
+	@chmod u+x "scripts/core/install"
+	@./scripts/core/install --only-git-init-sloth

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,11 @@ install:
 	@echo "Initilise .Sloth installation as repository..."
 	@chmod u+x "scripts/core/install"
 	@./scripts/core/install --only-git-init-sloth
+
+link:
+	@echo "Added link in /usr/local/bin for dot command"
+	@ln -s "${SLOTH_PATH}/bin/dot" /usr/local/bin/dot
+
+unlink:
+	@echo "Removed link in /usr/local/bin for dot command"
+	@rm -f /usr/local/bin/dot

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,24 @@
 default: install
 
 SLOTH_PATH=${SLOTH_PATH:-$(dirname $BASH_SOURCE)}
+DOTLY_INSTALLER=true
 
-install:
+all: init install loader link
+
+init:
 	@echo "Initilise .Sloth installation as repository..."
 	@chmod u+x "scripts/core/install"
 	@./scripts/core/install --only-git-init-sloth
+
+install:
+	if [[ -n "${DOTFILES_PATH:-}" ]]; then
+		@echo "Install dotfiles in: \`${DOTFILES_PATH}\`"
+		@chmod u+x ./scripts/dotfiles/create
+		@./scripts/dotfiles/create
+	fi
+
+	@chmod u+x "scripts/core/install"
+	@./scripts/core/install --ignore-symlinks --ignore-restoration
 
 link:
 	@echo "Added link in /usr/local/bin for dot command"
@@ -15,3 +28,9 @@ link:
 unlink:
 	@echo "Removed link in /usr/local/bin for dot command"
 	@rm -f /usr/local/bin/dot
+
+loader:
+	@echo "Installing loader for .Sloth..."
+	@chmod u+x "./bin/dot"
+	@./bin/dot core loader bashrc --modify
+	@./bin/dot core loader zshrc --modify

--- a/scripts/core/loader
+++ b/scripts/core/loader
@@ -95,6 +95,8 @@ check_has_dotfiles_var() {
   fi
 }
 
+script::depends_on docpars
+
 ##? Adds a .Sloth loader in your current dotfiles if it was not added. If you
 ##? want to edit .bashrc or .zshenv, with your desired valur for DOTFILES_PATH
 ##? and you do not have defined yet in .bashrc, .zshenv or .zshrc, you can


### PR DESCRIPTION
## Humman Changelog
- Added makefile
- Added `docpars` as dependency in `dot core loader` script.

## Description
- Added makefile to make easier standalone and custom installations.

## Motivation and Context
This simplify the installation process of sloth when you use standalone installations or installing by using any git release instead of `installer` script or using `git clone`.

## Tasks
<!---
Only for large PRs and when you have multiple stuff to do. Use this only if this is a WIP (Work In Progress) PR.
Delete if your PR is ready when you create the PR.
 --->
- [x] Apply linter `dot core lint` && `dot core lint --patch`
- [x] Check shellcheks that makes script to not pass the checks `dot core static_analysis`

 ## Other
<!--- If you want to add something add it here --->
