### PR TITLE
[Fix] DOTFILES_PATH unbound variable

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -179,7 +179,8 @@ else
       grep -q "/scripts/self/_main.sh" "${script_full_path}" ||
       grep -q "/scripts/self/src/_main.sh" "${script_full_path}"
   then
-    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="$DOTLY_PATH" DOTFILES_PATH="${DOTFILES_PATH:-}" "${script_full_path}" "$@"
+    #shellcheck disable=SC2098,SC2097
+    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "${script_full_path}" "$@"
   else
     #shellcheck disable=SC1090
     . "${script_full_path}"

--- a/shell/bash/init.sh
+++ b/shell/bash/init.sh
@@ -19,8 +19,13 @@ PATH=$(
 )
 export PATH
 
-themes_paths=(
-  "$DOTFILES_PATH/shell/bash/themes"
+themes_paths=()
+if [[ -n "${DOTFILES_PATH:-}" && -d "$DOTFILES_PATH/shell/bash/themes" ]]; then
+  themes_paths+=(
+    "$DOTFILES_PATH/shell/bash/themes"
+  )
+fi
+themes_paths+=(
   "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/bash/themes"
 )
 
@@ -40,8 +45,7 @@ fi
 
 #shellcheck disable=SC2068
 for THEME_PATH in ${themes_paths[@]}; do
-  SLOTH_THEME="${SLOTH_THEME:-DOTLY_THEME}"
-  THEME_PATH="${THEME_PATH}/${SLOTH_THEME:-codely}.sh"
+  THEME_PATH="${THEME_PATH}/${SLOTH_THEME:-${DOTLY_THEME:-codely}}.sh"
   THEME_COMMAND=""
   #shellcheck source=/dev/null
   [ -f "$THEME_PATH" ] && . "$THEME_PATH" && THEME_COMMAND="${PROMPT_COMMAND:-}" && break
@@ -50,7 +54,7 @@ done
 PROMPT_COMMAND="__right_prompt"
 export THEME_COMMAND PROMPT_COMMAND
 
-for completion in $(find "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/bash/completions/" "$DOTFILES_PATH/shell/bash/completions/" -name "_*" -print0 -exec echo {} \; 2> /dev/null | xargs -0 -I _ echo _); do
+for completion in $(find "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/bash/completions/" "${DOTFILES_PATH:-/dev/null}/shell/bash/completions/" -name "_*" -print0 -exec echo {} \; 2> /dev/null | xargs -0 -I _ echo _); do
   [[ -z "$completion" ]] && continue
   #shellcheck source=/dev/null
   . "$completion" || echo -e "\033[0;31mBASH completion '$completion' could not be loaded\033[0m"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -53,13 +53,16 @@ alias sloth='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias lazy='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias s='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 
-. "${DOTFILES_PATH}/shell/exports.sh" || echo ".Sloth initializer: Error loading user exports"
+if [[ -n "${DOTFILES_PATH:-}" && -d "${DOTFILES_PATH:-}" ]]; then
+  #User variables & configuration
+  [[ -r "${DOTFILES_PATH}/shell/exports.sh" ]] && . "${DOTFILES_PATH}/shell/exports.sh" || echo ".Sloth initializer: Error loading user exports"
 
-# Paths
-. "${DOTFILES_PATH}/shell/paths.sh" || echo ".Sloth initializer: Error loading user paths"
+  # Paths
+  [[ -r "${DOTFILES_PATH}/shell/paths.sh" ]] && . "${DOTFILES_PATH}/shell/paths.sh" || echo ".Sloth initializer: Error loading user paths"
+fi
 
 # Temporary store user path in paths (this is done to avoid do a breaking change and keep compatibility with dotly)
-user_paths=("${path[@]}")
+[[ -n "${path[*]:-}" ]] && user_paths=("${path[@]:-}")
 # Temporary PATH to the system paths
 PATH="${PATH:+${PATH}:}$(command -p getconf PATH)"
 
@@ -228,8 +231,10 @@ export PATH
 ###### End of .Sloth bin path first & Remove duplicated PATHs ######
 
 ###### User aliases & functions ######
-. "${DOTFILES_PATH}/shell/aliases.sh" || echo ".Sloth initializer: Error loading user aliases"
-. "${DOTFILES_PATH}/shell/functions.sh" || echo ".Sloth initializer: Error loading user functions"
+if [[ -n "${DOTFILES_PATH:-}" && -d "$DOTFILES_PATH" ]]; then
+  . "${DOTFILES_PATH}/shell/aliases.sh" || echo ".Sloth initializer: Error loading user aliases"
+  . "${DOTFILES_PATH}/shell/functions.sh" || echo ".Sloth initializer: Error loading user functions"
+fi
 ###### End of User aliases & functions ######
 
 ###### User init scripts ######
@@ -244,7 +249,7 @@ then
   for init_script in $(command -p find "${DOTFILES_PATH}/shell/init.scripts-enabled" -mindepth 1 -maxdepth 1 -not -iname ".*" -type f,l -print0 2> /dev/null | command -p xargs -0 -I _ realpath --quiet --logical _); do
     [[ -z "$init_script" ]] && continue
 
-    { [[ -f "$init_script" ]] && . "$init_script"; } || echo -e "\033[0;31m${init_script} could not be loaded\033[0m"
+    { [[ -r "$init_script" ]] && . "$init_script"; } || echo -e "\033[0;31m${init_script} could not be loaded\033[0m"
   done
 fi
 ###### End of User init scripts ######

--- a/shell/zsh/init.sh
+++ b/shell/zsh/init.sh
@@ -26,8 +26,10 @@ setopt +o nomatch
 # setopt autopushd
 
 # Start zim
-#shellcheck disable=SC1091
-. "${ZIM_HOME}/init.zsh"
+if [[ -n "${ZIM_HOME:-}" && -d "${ZIM_HOME:-}" && -r "${ZIM_HOME}/init.zsh" ]]; then
+  #shellcheck disable=SC1091
+  . "${ZIM_HOME}/init.zsh"
+fi
 
 # Async mode for autocompletion
 # shellcheck disable=SC2034
@@ -35,9 +37,15 @@ ZSH_AUTOSUGGEST_USE_ASYNC=true
 # shellcheck disable=SC2034
 ZSH_HIGHLIGHT_MAXLENGTH=300
 
-fpath=(
-  "${DOTFILES_PATH}/shell/zsh/themes"
-  "${DOTFILES_PATH}/shell/zsh/autocompletions"
+fpath=()
+if [[ -n "${DOTFILES_PATH:-}" && -d "$DOTFILES_PATH" ]]; then
+  fpath+=(
+    "${DOTFILES_PATH}/shell/zsh/themes"
+    "${DOTFILES_PATH}/shell/zsh/autocompletions"
+  )
+fi
+
+fpath+=(
   "${SLOTH_PATH}/shell/zsh/themes"
   "${SLOTH_PATH}/shell/zsh/completions"
   "${fpath[@]}"


### PR DESCRIPTION
## Humman Changelog
* Fix unbound variable for `DOTFILES_PATH` when is installed as standalone or not defined.

## Tasks
<!---
Only for large PRs and when you have multiple stuff to do. Use this only if this is a WIP (Work In Progress) PR.
Delete if your PR is ready when you create the PR.
 --->
- [x] Apply linter `dot core lint` && `dot core lint --patch`
- [x] Check shellcheks that makes script to not pass the checks `dot core static_analysis`
