### PR TITLE
[Feature] sloth as shebang

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -182,9 +182,13 @@ else
       grep -q "/scripts/self/src/_main.sh" "${script_full_path}"
   then
     #shellcheck disable=SC2098,SC2097
-    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "${script_full_path}" "$@"
+    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "$script_full_path" "$@"
   else
+    if ! grep -q "IGNORE_DOCOPT" "$script_full_path" || ! grep -q "IGNORE_DOCPARS" "$script_full_path"; then
+      docs::parse_script "$script_full_path" "$@"
+    fi
+
     #shellcheck disable=SC1090
-    . "${script_full_path}"
+    . "$script_full_path"
   fi
 fi

--- a/bin/dot
+++ b/bin/dot
@@ -163,6 +163,7 @@ else
   # Automatic --help and --version
   if [[ ! -x "$script_full_path" ]]; then
     output::error "The script \`$script_full_path\` does not exists"
+    exit 1
   elif [[ "$firstarg" == "-h" || "$firstarg" == "--help" ]]; then
     docs::parse_script "${script_full_path}" "--help"
     exit

--- a/bin/sloth
+++ b/bin/sloth
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+##### Start of Homebrew Installation Patch #####
+# export HOMEBREW_SLOTH=true
+# export SLOTH_PATH="HOMEBREW_PREFIX/opt/dot"
+##### End of Hombrew Installation Patch #####
+
+[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && echo "Error: Could not find where the .Sloth is installed." && exit 1
+
+#shellcheck disable=SC1091
+. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+
+if args::has_no_args "$@"; then
+  fzf_prompt "$(dot::list_scripts_path)"
+elif args::total_is 1 "$@" && [[ ! -x "${1:-}" ]]; then
+  fzf_prompt "$(dot::list_context_scripts "${1:-}")"
+else
+
+  #shellcheck disable=SC2034
+  SCRIPT_NAME="$(basename "$1")"
+  script_full_path="$1"
+  firstarg="${2:-}"
+
+  # Automatic --help and --version
+  if [[ ! -x "$script_full_path" ]]; then
+    output::error "The script \`$script_full_path\` does not exists or not executable"
+    exit 1
+  elif [[ "$firstarg" == "-h" || "$firstarg" == "--help" ]]; then
+    docs::parse_script "${script_full_path}" "--help"
+    exit
+  elif [[ "$firstarg" == "-v" || "$firstarg" == "--version" ]]; then
+    docs::parse_script "${script_full_path}" "--version"
+    exit
+  fi
+
+  #shellcheck disable=SC1090
+  . "${script_full_path}"
+fi

--- a/bin/sloth
+++ b/bin/sloth
@@ -25,14 +25,23 @@ else
 
   # Automatic --help and --version
   if [[ ! -x "$script_full_path" ]]; then
-    output::error "The script \`$script_full_path\` does not exists or not executable"
-    exit 1
+    #shellcheck disable=SC2097,SC2098
+    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "${SLOTH_PATH}/bin/dot" "$@"
+    exit $?
   elif [[ "$firstarg" == "-h" || "$firstarg" == "--help" ]]; then
-    docs::parse_script "${script_full_path}" "--help"
+    doc="$(docs::parse_script "${script_full_path}" "--help")"
+    [[ -n "$doc" ]] && echo -en "$doc"
     exit
   elif [[ "$firstarg" == "-v" || "$firstarg" == "--version" ]]; then
     docs::parse_script "${script_full_path}" "--version"
     exit
+  fi
+
+  # Remove script itself to be the first argument
+  shift
+
+  if ! grep -q "IGNORE_DOCOPT" "$script_full_path" || ! grep -q "IGNORE_DOCPARS" "$script_full_path"; then
+    docs::parse_script "$script_full_path" "$@"
   fi
 
   #shellcheck disable=SC1090

--- a/scripts/core/src/docs.sh
+++ b/scripts/core/src/docs.sh
@@ -35,7 +35,7 @@ docs::parse_script_version() {
   fi
 
   [[ -n "${SCRIPT_NAME:-}" ]] && builtin echo -n "${SCRIPT_NAME} "
-  builtin echo "${version:-0.0.0}"
+  builtin echo "${version:-v0.0.0}"
 }
 
 docs::parse() {

--- a/scripts/core/src/docs.sh
+++ b/scripts/core/src/docs.sh
@@ -14,7 +14,7 @@ docs::parse_docopt() {
     command -p awk "{ORS=(NR+1)%2==0?\"${green}\":RS}1" RS="\`" |
     command -p awk "{ORS=NR%1==0?\"${normal}\":RS}1" RS="\`")"
 
-  echo -e "$doc"
+  echo -e "${doc//\$0/${SCRIPT_NAME:-${BASH_SOURCE[0]:-}}}"
 }
 
 docs::parse_script_version() {

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -19,7 +19,6 @@
 ##?   clean_cache
 ##?   fix_permissions      Fix error: "zsh compinit: insecure directories"
 ##?
-##?
 #? v2.2.0
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "-v" || "${1:-}" == "--version" ]] || package::is_installed docpars; then
   docs::parse "$@"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -54,7 +54,6 @@ DOTLY_PATH="${DOTLY_PATH:-${SLOTH_PATH:-}}"
 
 # Sloth aliases and functions
 alias dotly='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
-alias sloth='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias lazy='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias s='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 

--- a/shell/zsh/completions/_dot
+++ b/shell/zsh/completions/_dot
@@ -1,4 +1,4 @@
-#compdef dot lazy=dot s=lazy
+#compdef dot lazy=dot s=lazy sloth=dot
 
 . "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
 


### PR DESCRIPTION
<!---
Please use English as main language
Provide a general summary of your changes in the Title above
Use prefix by type of change:
- [Feature]
- [Fix]
- [Doc]
Also add [HELP NEEDED] before if you need some∩ help.
Add also [WIP] before every other prefix if you have task to do or you have proposed task (because work in a team or you desire some help).
-->

## Humman Changelog
<!--
Provide a human changelog (does not need to be as your commits) with the changes you made, example:
- Fix: Issue #83
- Feature: Added new cool stuff...
--->
* Fix missing exit with error when a script is not executable by using `dot`
* Deleted `sloth` as shell alias.
* Some code formatting and help formatting for scripts.
* Added `sloth` completion
* Fix non parsing docopt when using a new way of loading scripts in `dot`
* You can use `sloth` as shebang instead of include all .Sloth libs or place scripts in specific folder.
* Added `v` for version when version of script is not specified.

## Description
<!--- Describe your changes -->
You can use .Sloth libraries by including `#!/usr/bin/env sloth` shebang in any script. So now is more flexible and you can use your own way for lazy scripts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes more flexible program and maybe more ideal for asking to be included in homebrew-core packages. It needs more improvements but I think this is in the right way to do that.

## How Has This Been Tested?
Tested locally by creating a sample script in a random folder outside of ~/.dotfiles with the content

```bash
#!/usr/bin/env sloth

##? This is a sample script
##?
##? Usage:
##?   $0 [-h | --help]
##?   $0 [-v | --version]
##?   $0

echo "Using .Sloth libraries"

command -v output::write
```

I called this script `test.sh` and gives to it `chmod +x`. After execution by calling `/path/to/test.sh`, `/path/to/test.sh -h` and `./test.sh` and `./test.sh -v`.

Gives to me the expected output. Try by yourself. The expected outputs are explained behind.

### for no arguments expected output is

```
Using .Sloth libraries
output::write
```

### For `-h` or `--help`

```
This is a sample script

Usage:
  test.sh [-h | --help]
  test.sh [-v | --version]
  test.sh
```

### For `-v` or `--version`

```
test.sh v0.0.0
```

`0.0.0` is the expected version when no version is provided by using `#?` (in as many lines you want, for example if you want to see version and copyright...), `##? SCRIPT_VERSION v1.0.0` or `##? SCRIPT_VERSION "v1.0.0"`

## Tasks
<!---
Only for large PRs and when you have multiple stuff to do. Use this only if this is a WIP (Work In Progress) PR.
Delete if your PR is ready when you create the PR.
 --->
- [ ] Apply linter `dot core lint` && `dot core lint --patch`
- [ ] Check shellcheks that makes script to not pass the checks `dot core static_analysis`
- [ ] Document the changes in the PR
- [ ] REAME doc

 ## Other
<!--- If you want to add something add it here --->
