### PR TITLE
[Fix] Missing vars for Homebrew

### DIFF
--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -1,5 +1,5 @@
 # Needed dotly/sloth functions
-#shellcheck disable=SC2148,SC1090,SC1091
+#shellcheck disable=SC2148,SC1090,SC1091,2034
 function cdd() {
   #shellcheck disable=SC2012
   cd "$(ls -d -- */ | fzf)" || echo "Invalid directory"
@@ -144,6 +144,9 @@ fi
 
 if [[ -n "$BREW_BIN" ]]; then
   HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$("$BREW_BIN" --prefix)}"
+  HOMEBREW_CELLAR="${HOMEBREW_CELLAR}/Cellar"
+  HOMEBREW_REPOSITORY="${HOMEBREW_REPOSITORY}/Homebrew"
+  HOMEBREW_SHELLENV_PREFIX="$HOMEBREW_REPOSITORY"
   PATH="${HOMEBREW_PREFIX}/bin${PATH:+:${PATH}}"
   # Brew add gnutools in macos or bsd only and brew paths
   if [[ "$SLOTH_OS" == Darwin* ]]; then


### PR DESCRIPTION
## Humman Changelog
* Added missing vars for brew: `HOMEBREW_CELLAR`, `HOMEBREW_REPOSITORY` & `HOMEBREW_SHELLENV_PREFIX`.

# Related issue
This avoid a warning when HOMEBREW_REPOSITORY is not set and Homebrew is not installed in the default location.