### PR TITLE
[fix] git delta as dependency

### DIFF
--- a/scripts/mac/defaults
+++ b/scripts/mac/defaults
@@ -25,6 +25,7 @@ docs::parse "$@"
 
 case $1 in
   "view_changed")
+    script::depends_on git-delta
     current_defaults_path="$(mktemp)"
     defaults read > "$current_defaults_path"
 


### PR DESCRIPTION
## Humman Changelog
Fixed git-delta as dependency in `dot mac defaults`
