### PR TITLE
[Feat] undot

### DIFF
--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -35,6 +35,16 @@ function recent_dirs() {
   cd "$(echo "$selected" | sed "s/\~/$escaped_home/")" || echo "Invalid directory"
 }
 
+function dot::undot() {
+  [[ -z "${DOTLY_PATH:-}" ]] && return 1
+  PATH="$(echo "$PATH" | sed -E "s|:${SLOTH_PATH:-${DOTLY_PATH:-}}/bin||g")"
+  printf 'export PATH="%s"' "${PATH//::/:}"
+}
+
+function dot::dotback() {
+  printf 'export PATH="%s/bin:%s"' "${SLOTH_PATH:-${DOTLY_PATH:-}}" "${PATH//::/:}"
+}
+
 ##### Start of Homebrew Installation Patch #####
 # export HOMEBREW_SLOTH=true
 # export SLOTH_PATH="HOMEBREW_PREFIX/opt/dot"
@@ -71,6 +81,8 @@ DOTLY_PATH="${DOTLY_PATH:-${SLOTH_PATH:-}}"
 alias dotly='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias lazy='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
 alias s='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
+alias undot='eval "$(dot::undot)"'
+alias dotback='eval "$(dot::dotback)"'
 
 if [[ -n "${DOTFILES_PATH:-}" && -d "${DOTFILES_PATH:-}" ]]; then
   #User variables & configuration


### PR DESCRIPTION
<!---
Please use English as main language
Provide a general summary of your changes in the Title above
Use prefix by type of change:
- [Feature]
- [Fix]
- [Doc]
Also add [HELP NEEDED] before if you need some∩ help.
Add also [WIP] before every other prefix if you have task to do or you have proposed task (because work in a team or you desire some help).
-->

## Humman Changelog
* Added `undot` to unload dot command.
* Added `dotback` to have back `dot` command after `undot`

## Description
Added two aliases in the loader to enable and disable `dot` command. You should know that this will disable all scripts and binaries in `${SLOTH_PATH}/bin`. So you will not be able to use of the scripts in that folder until you call `dotback`.

![undot](https://user-images.githubusercontent.com/1969593/182365720-f6ff445c-6f03-479c-82a3-fdaa6c5ea9ea.gif)


## Related Issue
* https://github.com/CodelyTV/dotly/issues/24

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have a way to drop `dot` command is easier than rename it. Use other `dot` commands like the turborepo's dot is necessary in some cases.