### PR TITLE
fix(bin/dot): remove --print0 from fzf selection prompt

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -116,14 +116,7 @@ fzf_prompt() {
     fzf_scripts+=("${fzf_context} ${fzf_script}")
   done
 
-  script="$(
-    printf "%s\n" "${fzf_scripts[@]}" |
-      files::fzf \
-        --sloth-core \
-        --preview 'dot::fzf_view_doc {}' \
-        --height 100% \
-        --print0
-  )"
+  script="$(printf "%s\n" "${fzf_scripts[@]}" | files::fzf --sloth-core --preview 'dot::fzf_view_doc {}' --height 100%)"
 
   printf "%s" "$script"
   read -r args


### PR DESCRIPTION
## Problema

Al ejecutar `dot` e interactuar con la seleccion via fzf, al pulsar Enter sobre un script se produce:

```
warning: command
core install
> The script <core install / > does not exist
```

## Causa

`--print0` separa la salida de fzf con null bytes. Cuando el script seleccionado contiene un espacio (ej. "core install"), el null byte entre palabras hace que bash interprete el primero como comando y el resto como argumentos rotos -> warning + dispatch fallido.

## Fix

Eliminar `--print0` de la invocacion de fzf. Como fzf single-select devuelve una sola linea, el separador null es innecesario.