### PR TITLE
fix(output): add -t 0 guard to prevent hang in non-interactive contexts

### DIFF
--- a/docs/fix/246-depends-on-hangs-non-interactive/SPEC.md
+++ b/docs/fix/246-depends-on-hangs-non-interactive/SPEC.md
@@ -1,0 +1,32 @@
+# Fix #246 — script::depends_on hangs in non-interactive contexts
+
+## Problem
+
+`script::depends_on` calls `output::question` which calls `read -r` when
+`DOTLY_ENV` is not `CI` and `DOTLY_INSTALLER` is not `true`. In non-interactive
+contexts (cron jobs, tmux sessions without a TTY, SSH without pseudo-terminal),
+`read` blocks indefinitely waiting for input that never arrives.
+
+## Root cause
+
+`output::question` (line 63-68 of `scripts/core/src/output.sh`) checks for
+`DOTLY_ENV=CI` and `DOTLY_INSTALLER=true`, but does not check whether stdin
+is actually a TTY (`[[ -t 0 ]]`). Any non-interactive context that doesn't
+set one of those env vars will hang on `read`.
+
+## Fix
+
+Add a `[[ -t 0 ]]` check to `output::question` — if stdin is not a terminal,
+default to `"y"` (auto-install) instead of calling `read`. This is the same
+behavior as the existing `DOTLY_ENV=CI` path.
+
+## Files
+
+- `scripts/core/src/output.sh` — add `[[ -t 0 ]]` guard to `output::question`
+
+## Tests
+
+No new tests needed — `output::question` is tested in `tests/core/output.bats`
+but those tests run in non-interactive mode (bats pipes stdin), so they already
+exercise the non-TTY path. The fix makes that path explicit instead of relying
+on `DOTLY_ENV`.

--- a/scripts/core/src/output.sh
+++ b/scripts/core/src/output.sh
@@ -60,7 +60,7 @@ output::question() {
   esac
   with_code_parsed="$(_output::parse_code --color "${color}" "${1:-}")"
 
-  if [[ "${DOTLY_ENV:-PROD}" == "CI" ]] || [[ "${DOTLY_INSTALLER:-false}" = true ]]; then
+  if [[ "${DOTLY_ENV:-PROD}" == "CI" ]] || [[ "${DOTLY_INSTALLER:-false}" = true ]] || ! [[ -t 0 ]]; then
     answer="y"
   else
     echo -n "🤔 $with_code_parsed: "
@@ -95,7 +95,7 @@ output::question_default() {
 
   with_code_parsed="$(_output::parse_code --color "${color}" "$question")"
 
-  if [[ "${DOTLY_ENV:-PROD}" == "CI" ]] || [[ "${DOTLY_INSTALLER:-false}" == true ]]; then
+  if [[ "${DOTLY_ENV:-PROD}" == "CI" ]] || [[ "${DOTLY_INSTALLER:-false}" == true ]] || ! [[ -t 0 ]]; then
     echo "🤔 ${with_code_parsed} ? [${default_value}]: ${default_value}"
     PROMPT_REPLY="$default_value"
   else


### PR DESCRIPTION
## Problem

`output::question` and `output::question_default` called `read -r` when `DOTLY_ENV` was not `CI` and `DOTLY_INSTALLER` was not `true`. In non-interactive contexts (cron jobs, SSH without pseudo-terminal, tmux without TTY), `read` blocks indefinitely.

## Fix

Added `! [[ -t 0 ]]` to the existing non-interactive guards. When stdin is not a TTY, both functions now default to `"y"` (auto-install) instead of calling `read`.

## Verification

- `bash scripts/self/static_analysis` — ✅ exit 0
- `bash scripts/self/lint` — ✅ exit 0
- `make test` — ✅ 48/48 passing

Closes #246