### PR TITLE
fix(up): track failed package managers and exit non-zero on failure

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -8,6 +8,7 @@
 
 update_all_error() {
   [[ -n "${1:-}" ]] && output::write "Error updating ${1:-} apps. See \`dot self debug\` for view errors"
+  failed_managers+=("${1:-}")
 }
 
 ##? Update all packages
@@ -35,6 +36,8 @@ output::h1_without_margin "♻️  Updating all the apps on your system"
 ! ${split:-false} && output::write "If you want to debug what's happening behind the scenes, you can execute \`dot self debug\` in parallel."
 output::empty_line
 
+declare -a failed_managers=()
+
 if [[ -z "${package_managers[*]:-}" ]]; then
   readarray -t package_managers < <(package::get_all_package_managers "is_available" "update_all")
 fi
@@ -52,4 +55,10 @@ for package_manager in "${package_managers[@]}"; do
 done
 
 output::empty_line
-log::success '👌 All your packages have been successfully updated'
+if [[ ${#failed_managers[@]} -gt 0 ]]; then
+  output::error "Failed to update: ${failed_managers[*]}"
+  output::write "Check logs with \`dot self debug\`"
+  exit 1
+else
+  log::success '👌 All your packages have been successfully updated'
+fi

--- a/docs/fix/245-success-message-false-positive/SPEC.md
+++ b/docs/fix/245-success-message-false-positive/SPEC.md
@@ -1,0 +1,28 @@
+# Fix #245 — Success message always shown despite failures
+
+## Problem
+
+`bin/up` always shows `log::success '👌 All your packages have been
+successfully updated'` at the end, even when `update_all_error` was called for
+one or more package managers. The exit code is always 0.
+
+## Root cause
+
+The loop at line 50 calls `update_all_error` on failure but does not track
+which managers failed or set a non-zero exit code. The success message at
+line 55 runs unconditionally.
+
+## Fix
+
+Track failed package managers in an array. After the loop, if any failed,
+show an error message listing them and exit 1. Otherwise show the success
+message.
+
+## Files
+
+- `bin/up` — add `failed_managers` array, track failures, conditional exit
+
+## Tests
+
+No new tests — `bin/up` requires package managers and is not currently tested
+in bats. The fix is a straightforward conditional.


### PR DESCRIPTION
## Problem

`bin/up` always showed `log::success` at the end, even when `update_all_error` was called for one or more package managers. Exit code was always 0.

## Fix

- Track failed package managers in a `failed_managers` array
- `update_all_error` now appends to the array
- After the loop, if any managers failed: show error + exit 1
- Otherwise: show success message as before

## Verification

- `bash scripts/self/static_analysis` — ✅ exit 0
- `bash scripts/self/lint` — ✅ exit 0
- `make test` — ✅ 48/48 passing

Closes #245