### PR TITLE
fix(update): correct disable default, fix stale URLs, declare local branch

### DIFF
--- a/docs/fix/233-auto-updater-broken/REVIEW.md
+++ b/docs/fix/233-auto-updater-broken/REVIEW.md
@@ -1,0 +1,32 @@
+# Review Report — Fix #233 Auto-updater broken
+
+**Branch:** fix/233-auto-updater-broken
+**Commit:** 406ec1d
+**Date:** 2026-07-04
+**Size:** S (single-pass)
+
+## Diff Summary
+5 files changed, 63 insertions(+), 9 deletions(-)
+
+- `scripts/core/update` — Bug 1: `${disable:-enable}` → `${disable:-false}`
+- `scripts/core/src/sloth_update.sh` — Bug 2: 4× `sloth.git` → `dotSloth.git`; Bug 3: `branch` added to `local`
+- `scripts/core/version` — Bug 2: 1× `sloth.git` → `dotSloth.git`
+- `docs/fix/233-auto-updater-broken/SPEC.md` — SPEC
+- `docs/fix/README.md` — Fix index updated
+
+## Gate Results
+- `bash scripts/self/static_analysis` — exit 0 ✅
+- `bash scripts/self/lint` — exit 0 ✅
+- `make test` — 48/48 ✅
+
+## Findings
+
+### F-1 (Non-fix-now, drop)
+`docs/fix/README.md` pre-filled with PR #260 before PR exists. PR stage will correct the number if different.
+
+### F-2 (Non-fix-now, postpone)
+No dedicated tests for `sloth_update.sh`. Project limitation, documented in prior runs.
+
+## Verdict: MERGE-READY
+
+All three bugs fixed correctly per SPEC. Gate green. No fix-now findings.

--- a/docs/fix/233-auto-updater-broken/SPEC.md
+++ b/docs/fix/233-auto-updater-broken/SPEC.md
@@ -1,0 +1,54 @@
+# Fix #233 — Auto-updater broken
+
+## Issue
+[#233](https://github.com/gtrabanco/dotSloth/issues/233)
+
+## Root Causes
+
+### Bug 1 (Critical): `${disable:-enable}` default executes bash builtin
+**File:** `scripts/core/update:27`
+**Code:** `if ${disable:-enable}; then`
+**Problem:** When `--disable` is not passed, the default value is the string `enable`.
+Bash executes it as a command (the `enable` builtin), which always returns 0.
+This means the disable path (`touch .sloth_force_current_version; exit 0`) runs
+on every invocation, blocking all updates unconditionally.
+
+**Fix:** Change default to `false`: `if ${disable:-false}; then`
+
+### Bug 2 (Medium): Stale `sloth.git` fallback URLs
+**Files:** `scripts/core/src/sloth_update.sh` (4 sites), `scripts/core/version` (1 site)
+**Problem:** Five fallback URLs reference `github.com:gtrabanco/sloth.git`, a
+repository that no longer exists (renamed to `dotSloth`). These are last-resort
+fallbacks behind `SLOTH_DEFAULT_GIT_SSH_URL` (which is correct), so they only
+fire when the env var is unset AND the gitmodules file is absent — rare in
+practice but silent failure when they do.
+
+**Fix:** Replace all `sloth.git` fallbacks with `dotSloth.git`.
+
+### Bug 3 (Low): Undeclared `branch` variable in `sloth_update::sloth_update()`
+**File:** `scripts/core/src/sloth_update.sh:241`
+**Code:** `branch="${3:-${SLOTH_DEFAULT_BRANCH:-main}}"`
+**Problem:** `branch` is assigned but not declared in the `local` statement at
+line 238 (`local remote url default_branch head_branch force_update updated_version`).
+Under `set -u` this can leak the variable to the global scope.
+
+**Fix:** Add `branch` to the `local` declaration.
+
+## Scope
+- `scripts/core/update` — Bug 1
+- `scripts/core/src/sloth_update.sh` — Bugs 2 + 3
+- `scripts/core/version` — Bug 2 (one site)
+
+## Verification
+```bash
+PROJECT_ROOT=/Users/gtrabanco/MyProjects/dotSloth \
+SLOTH_PATH=/Users/gtrabanco/MyProjects/dotSloth \
+DOTLY_PATH=/Users/gtrabanco/MyProjects/dotSloth \
+bash scripts/self/static_analysis
+
+dot core lint
+
+make test
+```
+
+## Size: S

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| | Auto-updater broken | pending | — | [#233](https://github.com/gtrabanco/dotSloth/issues/233) |
+| 233-auto-updater-broken | Auto-updater broken | in-progress | — | [#233](https://github.com/gtrabanco/dotSloth/issues/233) |
 | | Restorer broken | pending | — | [#234](https://github.com/gtrabanco/dotSloth/issues/234) |
 | | up command fails to parse updates | pending | — | [#235](https://github.com/gtrabanco/dotSloth/issues/235) |
 | | pip::update_apps() double install typo | done | — | [#243](https://github.com/gtrabanco/dotSloth/issues/243) |

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| 233-auto-updater-broken | Auto-updater broken | in-progress | — | [#233](https://github.com/gtrabanco/dotSloth/issues/233) |
+| 233-auto-updater-broken | Auto-updater broken | done · [#260](https://github.com/gtrabanco/dotSloth/pull/260) | — | [#233](https://github.com/gtrabanco/dotSloth/issues/233) |
 | | Restorer broken | pending | — | [#234](https://github.com/gtrabanco/dotSloth/issues/234) |
 | | up command fails to parse updates | pending | — | [#235](https://github.com/gtrabanco/dotSloth/issues/235) |
 | | pip::update_apps() double install typo | done | — | [#243](https://github.com/gtrabanco/dotSloth/issues/243) |

--- a/scripts/core/src/sloth_update.sh
+++ b/scripts/core/src/sloth_update.sh
@@ -58,7 +58,7 @@ sloth_update::sloth_repository_set_ready() {
   fi
 
   if ! git::is_in_repo "${SLOTH_UPDATE_GIT_ARGS[@]}" || ! git::check_remote_exists "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_UPDATE_GIT_ARGS[@]}"; then
-    git::init_repository_if_necessary "${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}" "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_DEFAULT_BRANCH:-main}" "${SLOTH_UPDATE_GIT_ARGS[@]}"
+    git::init_repository_if_necessary "${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}" "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_DEFAULT_BRANCH:-main}" "${SLOTH_UPDATE_GIT_ARGS[@]}"
   fi
 
   # Set head branch
@@ -104,7 +104,7 @@ sloth_update::get_latest_stable_version() {
     -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
   )
 
-  local url="${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}"
+  local url="${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}"
   url="${url//git+ssh:\/\//}"
 
   # .Sloth were installed using a package manager
@@ -114,7 +114,7 @@ sloth_update::get_latest_stable_version() {
     exit
   fi
 
-  git::remote_latest_tag_version "${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}" "v*.*.*" "${SLOTH_UPDATE_GIT_ARGS[@]}"
+  git::remote_latest_tag_version "${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}" "v*.*.*" "${SLOTH_UPDATE_GIT_ARGS[@]}"
 }
 
 #;
@@ -235,9 +235,9 @@ sloth_update::exists_migration_script() {
 # @return 0 if all ok, error code otherwise 10, in no force means has pending commits or dirty directory, 20 remote does not exists or can't be set, no default branch, 40 git pull fails
 #"
 sloth_update::sloth_update() {
-  local remote url default_branch head_branch force_update updated_version
+  local remote url default_branch branch head_branch force_update updated_version
   remote="${1:-${SLOTH_DEFAULT_REMOTE:-origin}}"
-  url="${2:-${SLOTH_GITMODULES_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}}"
+  url="${2:-${SLOTH_GITMODULES_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}}"
   branch="${3:-${SLOTH_DEFAULT_BRANCH:-main}}"
   default_remote_branch="${remote}/${branch}"
   force_update="${4:-false}"
@@ -312,7 +312,7 @@ sloth_update::gracefully() {
   fi
 
   # Force update
-  sloth_update::sloth_update "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_GITMODULES_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}" "${SLOTH_DEFAULT_BRANCH:-main}" true || exit_code=$?
+  sloth_update::sloth_update "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_GITMODULES_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}" "${SLOTH_DEFAULT_BRANCH:-main}" true || exit_code=$?
 
   return $exit_code
 }

--- a/scripts/core/update
+++ b/scripts/core/update
@@ -24,7 +24,7 @@ void() {
 #? v3.0.0
 docs::parse "$@"
 
-if ${disable:-enable}; then
+if ${disable:-false}; then
   touch "$DOTFILES_PATH/.sloth_force_current_version"
   exit 0
 elif ${enable:-false}; then

--- a/scripts/core/version
+++ b/scripts/core/version
@@ -35,7 +35,7 @@ check_local_tag_exists() {
 docs::parse "$@"
 
 if ${view_remote:-false}; then
-  SLOTH_DEFAULT_URL="${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/sloth.git}}"
+  SLOTH_DEFAULT_URL="${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}"
   git::git "${SLOTH_UPDATE_GIT_ARGS[@]:-}" ls-remote --tags --refs "$SLOTH_DEFAULT_URL" "v*.*.*" 2> /dev/null | awk '{gsub("\\^{}","", $NF);gsub("refs/tags/v",""); print $NF}' | sort -Vur
   exit 0
 fi


### PR DESCRIPTION
Closes #233

## Summary

Fixes three bugs in the dotSloth auto-updater that together blocked all updates unconditionally.

## Root causes & fixes

**Bug 1 (Critical) — `scripts/core/update:27`:**
```diff
-if ${disable:-enable}; then
+if ${disable:-false}; then
```
The default `enable` executed the bash builtin `enable` (always returns 0), so the disable path ran on every invocation — blocking all updates unconditionally. Changed the default to `false`.

**Bug 2 (Medium) — stale `sloth.git` fallback URLs:**
Replaced all 6 occurrences of `gtrabanco/sloth.git` with `gtrabanco/dotSloth.git` in fallback URL strings across `scripts/core/src/sloth_update.sh` (5 sites) and `scripts/core/version` (1 site). These last-resort fallbacks only fire when `SLOTH_DEFAULT_GIT_SSH_URL` is unset AND the gitmodules file is absent — rare but silent failure when they do.

**Bug 3 (Low) — `scripts/core/src/sloth_update.sh:238`:**
```diff
-local remote url default_branch head_branch force_update updated_version
+local remote url default_branch branch head_branch force_update updated_version
```
`branch` was assigned at line 241 but not declared in the `local` statement, leaking to global scope under `set -u`.

## Verification gate (all green, exit 0)

- `bash scripts/self/static_analysis` → exit 0
- `bash scripts/self/lint` → exit 0
- `make test` → exit 0 (48/48 tests pass)
- shfmt `-ln bash -sr -ci -i 2` applied to all modified files (no formatting changes beyond the fixes)