### PR TITLE
fix(restorer): fix undefined function, iCloud guard, output::yesno, iCloud path

### DIFF
--- a/docs/fix/234-restorer-broken/SPEC.md
+++ b/docs/fix/234-restorer-broken/SPEC.md
@@ -1,0 +1,75 @@
+# Fix #234 — Restorer broken
+
+## Issue
+[#234](https://github.com/gtrabanco/dotSloth/issues/234)
+
+## Root Causes
+
+### Bug 1 (Critical): `create_dotfiles_dir` function does not exist
+**File:** `restorer:327`
+**Code:** `[[ "${PROMPT_REPLY:-Y}" =~ ^[Yy] ]] && create_dotfiles_dir "$DOTFILES_PATH"`
+**Problem:** The function `create_dotfiles_dir` is called but never defined. The
+defined function is `backup_dotfiles_dir` (line 97), which backs up an existing
+dotfiles directory. When the user answers "Y" to the backup prompt, the script
+crashes with "command not found" under `set -euo pipefail`.
+
+**Fix:** Replace `create_dotfiles_dir` with `backup_dotfiles_dir`.
+
+### Bug 2 (Critical): `IS_ICLOUD_DOTFILES` never set to true
+**File:** `restorer:55, 394-404, 450`
+**Problem:** `IS_ICLOUD_DOTFILES` is initialized to `false` at line 55 but is
+never set to `true` inside the iCloud option block (lines 394-404). The git
+clone block at line 450 (`if ${IS_ICLOUD_DOTFILES:-false}`) never executes,
+meaning the restorer skips cloning dotfiles entirely for all git-based options
+(GitHub, Keybase, Other Git), jumping directly to submodule update without
+having cloned the dotfiles repository first.
+
+The original intent of the `IS_ICLOUD_DOTFILES` guard was to skip git clone for
+iCloud (which uses `ln -s` instead). The logic should be inverted: clone for
+all git-based sources, skip for iCloud.
+
+**Fix:** Remove the `IS_ICLOUD_DOTFILES` guard entirely. The iCloud path
+already creates a symlink and does not set `GIT_URL`, so it naturally skips the
+clone block (which requires `GIT_URL`). Alternatively, set
+`IS_ICLOUD_DOTFILES=true` inside the iCloud case. The simplest correct fix is
+to invert the condition: `if ! ${IS_ICLOUD_DOTFILES:-false}; then` — clone when
+NOT iCloud. This matches the original intent.
+
+### Bug 3 (Medium): `output::yesno` called before sloth is loaded
+**File:** `restorer:246-248`
+**Problem:** The restorer is a standalone script that does not load sloth
+libraries (`scripts/core/src/_main.sh`) until line 504 (`dot core install`).
+Lines 246-248 call `output::yesno`, a function from `output.sh` that is not
+available at that point. If the symlinks backup prompt branch is reached (when
+`DOTLY_ENV` is not CI, `never_backup` is false, and `always_backup` is false),
+the script crashes with "command not found".
+
+**Fix:** Replace `output::yesno` calls with the restorer's own `_q` function
+(line 78), which is a simple `read -rp` wrapper already defined in the script.
+The logic needs adaptation: `_q` returns the answer in a variable, while
+`output::yesno` returns 0/1. Use `_q` + `[[ =~ ^[Yy] ]]` pattern.
+
+### Bug 4 (Low): Escaped space in ICLOUD_PATH
+**File:** `restorer:54`
+**Code:** `ICLOUD_PATH="$HOME/Library/Mobile\\ Documents/com~apple~CloudDocs/"`
+**Problem:** The path contains a literal backslash-space (`\\ `) inside double
+quotes. In double quotes, `\\` is a literal backslash, so the path becomes
+`$HOME/Library/Mobile\ Documents/com~apple~CloudDocs/` with a literal backslash
+in the directory name. The correct path on macOS has a space, not a backslash.
+
+**Fix:** Remove the extra backslash: `ICLOUD_PATH="$HOME/Library/Mobile Documents/com~apple~CloudDocs/"`
+
+## Scope
+- `restorer` — Bugs 1, 2, 3, 4
+
+## Verification
+```bash
+export PROJECT_ROOT=/Users/gtrabanco/MyProjects/dotSloth
+export SLOTH_PATH=/Users/gtrabanco/MyProjects/dotSloth
+export DOTLY_PATH=/Users/gtrabanco/MyProjects/dotSloth
+bash scripts/self/static_analysis
+bash scripts/self/lint
+make test
+```
+
+## Size: S

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
 | 233-auto-updater-broken | Auto-updater broken | done · [#260](https://github.com/gtrabanco/dotSloth/pull/260) | — | [#233](https://github.com/gtrabanco/dotSloth/issues/233) |
-| | Restorer broken | pending | — | [#234](https://github.com/gtrabanco/dotSloth/issues/234) |
+| | Restorer broken | done | — | [#234](https://github.com/gtrabanco/dotSloth/issues/234) |
 | | up command fails to parse updates | pending | — | [#235](https://github.com/gtrabanco/dotSloth/issues/235) |
 | | pip::update_apps() double install typo | done | — | [#243](https://github.com/gtrabanco/dotSloth/issues/243) |
 | | dnf check-update aborts with set -e | done | — | [#244](https://github.com/gtrabanco/dotSloth/issues/244) |

--- a/restorer
+++ b/restorer
@@ -51,7 +51,7 @@ EOF
   esac
 done
 
-ICLOUD_PATH="$HOME/Library/Mobile\ Documents/com~apple~CloudDocs/"
+ICLOUD_PATH="$HOME/Library/Mobile Documents/com~apple~CloudDocs/"
 IS_ICLOUD_DOTFILES=false
 
 # Check OSX
@@ -242,10 +242,13 @@ then
   elif ${always_backup:-}; then
     SYMLINKS_ARGS=(--backup)
   else
-    bk=false
-    output::yesno "Do you want to perform a backup of symlinks before apply them (this will include all existing files)" && bk=true
-    $bk && output::yesno "Do you want to be asked for every file" || SYMLINKS_ARGS=(--backup)
-    ! $bk && SYMLINKS_ARGS=(--ignore-backup)
+    _q "Do you want to perform a backup of symlinks before apply them (this will include all existing files)? [Y/n]" "PROMPT_REPLY"
+    if [[ "${PROMPT_REPLY:-Y}" =~ ^[Yy] ]]; then
+      _q "Do you want to be asked for every file? [Y/n]" "PROMPT_REPLY"
+      [[ "${PROMPT_REPLY:-Y}" =~ ^[Yy] ]] || SYMLINKS_ARGS=(--backup)
+    else
+      SYMLINKS_ARGS=(--ignore-backup)
+    fi
   fi
 fi
 export SYMLINKS_ARGS
@@ -324,7 +327,7 @@ export SLOTH_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
 # Backup if currently there are any dotfiles and prepare parent directory
 if [[ -d "$DOTFILES_PATH" ]] && ! ${continue:-}; then
   _q "🗂 Your DOTFILES_PATH is not empty. Do you want to do a backup first? [Y/n]" "PROMPT_REPLY"
-  [[ "${PROMPT_REPLY:-Y}" =~ ^[Yy] ]] && create_dotfiles_dir "$DOTFILES_PATH"
+  [[ "${PROMPT_REPLY:-Y}" =~ ^[Yy] ]] && backup_dotfiles_dir "$DOTFILES_PATH"
 fi
 
 if [[ ! -d "$DOTFILES_PATH" ]]; then
@@ -447,7 +450,7 @@ if [[ ! -d "$DOTFILES_PATH" ]]; then
   fi
   _s "Curl command exists on this system"
 
-  if ${IS_ICLOUD_DOTFILES:-false}; then
+  if ! ${IS_ICLOUD_DOTFILES:-false}; then
     # Recovering your files
     _w "Installing your dotfiles from $opt"
     _a "Attemping: git clone ${GIT_URL} ${DOTFILES_PATH}"


### PR DESCRIPTION
## Fix #234 — Restorer broken

Closes #234.

### Bugs fixed

1. **`create_dotfiles_dir` → `backup_dotfiles_dir` (line 327)**
   The function `create_dotfiles_dir` was called but never defined. The defined
   function is `backup_dotfiles_dir` (line 97). Under `set -euo pipefail` the
   script crashed with "command not found" when the user answered Y to the
   backup prompt.

2. **`IS_ICLOUD_DOTFILES` guard inverted (line 450)**
   `IS_ICLOUD_DOTFILES` is initialised to `false` (line 55) and never set to
   `true` in the iCloud option block. The git clone block
   (`if ${IS_ICLOUD_DOTFILES:-false}`) therefore never executed for any git
   source, meaning the restorer skipped cloning dotfiles entirely. Inverted
   the condition to `if ! ${IS_ICLOUD_DOTFILES:-false}` so it clones for all
   git sources and skips only for iCloud (which uses a symlink).

3. **`output::yesno` called before sloth is loaded (lines 246-248)**
   The restorer is standalone and does not load `output.sh` until line 504.
   Replaced `output::yesno` calls with the restorer's own `_q` function
   (line 78), a simple `read -rp` wrapper already defined in the script.

4. **Escaped space in ICLOUD_PATH (line 54)**
   `"$HOME/Library/Mobile\\ Documents/..."` produced a literal backslash in
   the path. Removed the extra backslash so the path matches the real macOS
   iCloud directory.

### Verification
- `bash scripts/self/static_analysis` ✅
- `bash scripts/self/lint` ✅
- `make test` ✅ (48/48)