### PR TITLE
refactor: replace DOTLY_PATH fallback pattern with canonical SLOTH_PATH

### DIFF
--- a/docs/fix/255-reconcile-path-variables/SPEC.md
+++ b/docs/fix/255-reconcile-path-variables/SPEC.md
@@ -1,0 +1,64 @@
+# Fix #255 — Reconcile DOTLY_PATH and SLOTH_PATH variable compatibility
+
+## Issue
+[#255](https://github.com/gtrabanco/dotSloth/issues/255)
+
+## Approach: Option A — Single canonical variable
+
+`SLOTH_PATH` is the canonical variable. All `${SLOTH_PATH:-${DOTLY_PATH:-}}`
+fallback patterns are replaced with `$SLOTH_PATH`. The compatibility mechanism
+in `shell/init-sloth.sh` (lines 76-78) already sets `SLOTH_PATH` from
+`DOTLY_PATH` if the former is unset, so `DOTLY_PATH` remains as a
+backward-compat alias.
+
+## Scope
+
+53 occurrences across 13 files:
+
+| File | Count |
+|------|-------|
+| shell/init-sloth.sh | 13 |
+| scripts/core/src/sloth_update.sh | 9 |
+| scripts/core/src/dot.sh | 8 |
+| scripts/package/src/recipes/nvm.sh | 4 |
+| scripts/core/src/dotly.sh | 4 |
+| scripts/core/src/package.sh | 3 |
+| scripts/core/src/files.sh | 3 |
+| dotfiles_template/shell/aliases.sh | 3 |
+| shell/bash/init.sh | 2 |
+| scripts/init/src/init.sh | 1 |
+| scripts/core/src/script.sh | 1 |
+| scripts/core/src/registry.sh | 1 |
+| scripts/core/src/_main.sh | 1 |
+
+## Changes
+
+1. Replace all `${SLOTH_PATH:-${DOTLY_PATH:-}}` with `${SLOTH_PATH:-}`
+   (preserving the `:-` for empty-string safety, but dropping the DOTLY_PATH
+   fallback since init-sloth.sh guarantees SLOTH_PATH is set).
+2. Keep `shell/init-sloth.sh` lines 76-78 as-is — this is the compatibility
+   layer that sets both variables from whichever is available.
+3. Do NOT remove `DOTLY_PATH` references entirely — it's still set as an alias
+   for backward compatibility. Only remove the inline fallback pattern.
+
+## Risk Assessment
+
+- **Low risk**: The init-sloth.sh compatibility layer runs before any script
+  that uses SLOTH_PATH, guaranteeing it's set.
+- **Tests**: All tests already use SLOTH_PATH directly (no fallback), so no
+  test changes needed.
+- **Backward compat**: Users who set DOTLY_PATH in their shell config will
+  still work because init-sloth.sh copies it to SLOTH_PATH.
+
+## Verification
+```bash
+export PROJECT_ROOT=/Users/gtrabanco/MyProjects/dotSloth
+export SLOTH_PATH=/Users/gtrabanco/MyProjects/dotSloth
+export DOTLY_PATH=/Users/gtrabanco/MyProjects/dotSloth
+bash scripts/self/static_analysis
+bash scripts/self/lint
+make test
+```
+
+## Size: M
+## Auto-merge: NO — requires manual review (tech-debt refactor, 53 changes across 13 files)

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -23,6 +23,7 @@ history lives in git log + closed issues.
 | 246-depends-on-hangs-non-interactive | script::depends_on hangs in non-interactive contexts | done · [#258](https://github.com/gtrabanco/dotSloth/pull/258) | — | [#246](https://github.com/gtrabanco/dotSloth/issues/246) |
 | 247-pkill-tmux-destroys-sessions | pkill tmux destroys all system sessions | done · [#257](https://github.com/gtrabanco/dotSloth/pull/257) | — | [#247](https://github.com/gtrabanco/dotSloth/issues/247) |
 || 248-mas-update-all-slow | mas::update_all() is slow and may hang | done · [#252](https://github.com/gtrabanco/dotSloth/pull/252) | — | [#248](https://github.com/gtrabanco/dotSloth/issues/248) |
+| 255-reconcile-path-variables | Reconcile DOTLY_PATH and SLOTH_PATH variable compatibility | done | — | [#255](https://github.com/gtrabanco/dotSloth/issues/255) |
 
 ## Conventions
 

--- a/dotfiles_template/shell/aliases.sh
+++ b/dotfiles_template/shell/aliases.sh
@@ -10,17 +10,17 @@ alias dotfiles='cd $DOTFILES_PATH'
 
 # Git
 alias gaa="git add -A"
-alias gc='${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot git commit'
+alias gc='${SLOTH_PATH:-}/bin/dot git commit'
 alias gca="git add --all && git commit --amend --no-edit"
 alias gco="git checkout"
-alias gd='${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot git pretty-diff'
+alias gd='${SLOTH_PATH:-}/bin/dot git pretty-diff'
 alias gs="git status -sb"
 alias gf="git fetch --all -p"
 alias gps="git push"
 alias gpsf="git push --force"
 alias gpl="git pull --rebase --autostash"
 alias gb="git branch"
-alias gl='${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot git pretty-log'
+alias gl='${SLOTH_PATH:-}/bin/dot git pretty-log'
 
 # Utils
 alias k='kill -9'

--- a/scripts/core/src/_main.sh
+++ b/scripts/core/src/_main.sh
@@ -7,7 +7,7 @@ SLOTH_SCRIPT_BASE_NAME="dot"
 if ! ${DOT_MAIN_SOURCED:-false}; then
   # platform and output should be at the first place because they are used
   # in other libraries
-  for file in "${SLOTH_PATH:-${DOTLY_PATH:-}}"/scripts/core/src/{log,platform,output,args,array,async,collections,docs,dot,files,git,github,json,package,registry,script,str,sloth_update,yaml,wrapped}.sh; do
+  for file in "${SLOTH_PATH:-}"/scripts/core/src/{log,platform,output,args,array,async,collections,docs,dot,files,git,github,json,package,registry,script,str,sloth_update,yaml,wrapped}.sh; do
     #shellcheck source=/dev/null
     . "$file" || exit 5
   done

--- a/scripts/core/src/_main.sh
+++ b/scripts/core/src/_main.sh
@@ -4,6 +4,12 @@
 #shellcheck disable=SC2034
 SLOTH_SCRIPT_BASE_NAME="dot"
 
+# Resolve SLOTH_PATH from DOTLY_PATH for backward compatibility
+# This ensures SLOTH_PATH is always set before any library is loaded,
+# even when only DOTLY_PATH is provided (e.g. CI, direct script invocation)
+SLOTH_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
+DOTLY_PATH="${DOTLY_PATH:-${SLOTH_PATH:-}}"
+
 if ! ${DOT_MAIN_SOURCED:-false}; then
   # platform and output should be at the first place because they are used
   # in other libraries

--- a/scripts/core/src/dot.sh
+++ b/scripts/core/src/dot.sh
@@ -4,7 +4,7 @@
 [[ -z "${SCRIPT_LOADED_LIBS[*]:-}" ]] && SCRIPT_LOADED_LIBS=()
 
 dot::list_contexts() {
-  dotly_contexts=$(command -p find "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts" -maxdepth 1 -type d,l -print0 2> /dev/null | command -p xargs -0 -I _ command -p basename _)
+  dotly_contexts=$(command -p find "${SLOTH_PATH:-}/scripts" -maxdepth 1 -type d,l -print0 2> /dev/null | command -p xargs -0 -I _ command -p basename _)
 
   [[ -n "${DOTFILES_PATH:-}" ]] &&
     dotfiles_contexts=$(command -p find "${DOTFILES_PATH:-}/scripts" -maxdepth 1 -type d,l -print0 2> /dev/null | command -p xargs -0 -I _ command -p basename _)
@@ -17,7 +17,7 @@ dot::list_context_scripts() {
   local -r context="${1:-}"
 
   if [[ -n "$context" ]]; then
-    readarray -t core_contexts < <(command -p find "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/$context" -mindepth 1 -maxdepth 1 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
+    readarray -t core_contexts < <(command -p find "${SLOTH_PATH:-}/scripts/$context" -mindepth 1 -maxdepth 1 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
     [[ -n "${DOTFILES_PATH:-}" ]] &&
       readarray -t dotfiles_contexts < <(command -p find "${DOTFILES_PATH:-}/scripts/$context" -mindepth 1 -maxdepth 1 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
 
@@ -38,7 +38,7 @@ dot::list_scripts() {
 dot::list_scripts_path() {
   local core_contexts dotfiles_contexts
 
-  readarray -t core_contexts < <(command -p find "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts" -mindepth 2 -maxdepth 2 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
+  readarray -t core_contexts < <(command -p find "${SLOTH_PATH:-}/scripts" -mindepth 2 -maxdepth 2 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
   [[ -n "${DOTFILES_PATH:-}" ]] &&
     readarray -t dotfiles_contexts < <(command -p find "${DOTFILES_PATH:-}/scripts" -mindepth 2 -maxdepth 2 -not -iname "_*" -not -iname ".*" -type f -print0 2> /dev/null | command -p xargs -0 -I _ echo _)
 
@@ -67,11 +67,11 @@ dot::fzf_view_doc() {
 
   if
     [[ 
-      -x "${SLOTH_PATH:-${DOTLY_PATH:-/dev/null}}/scripts/${context}/${script}" ||
+      -x "${SLOTH_PATH:-/dev/null}/scripts/${context}/${script}" ||
       -x "${DOTFILES_PATH:-/dev/null}/scripts/${context}/${script}" ]]
   then
 
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" "$context" "$script" --help
+    "${SLOTH_PATH:-}/bin/dot" "$context" "$script" --help
   fi
 }
 
@@ -111,7 +111,7 @@ dot::load_library() {
       # Context
       lib_paths+=(
         "${DOTFILES_PATH:-/dev/null}/scripts/$2/src"
-        "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/$2/src"
+        "${SLOTH_PATH:-}/scripts/$2/src"
       )
 
       # Valid path
@@ -125,7 +125,7 @@ dot::load_library() {
 
     # Finally core library
     lib_paths+=(
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src"
+      "${SLOTH_PATH:-}/scripts/core/src"
     )
 
     # Full path library is preferred
@@ -167,7 +167,7 @@ dot::load_library() {
 dot::_escape_dotfiles_paths() {
   local -r to_escape_path="${1:-$(< /dev/stdin)}"
   printf $'%s\0' "$to_escape_path" |
-    sed -e "s|${SLOTH_PATH:-${DOTLY_PATH:-}}|\${SLOTH_PATH:-\${DOTLY_PATH}}|g" |
+    sed -e "s|${SLOTH_PATH:-}|\${SLOTH_PATH:-}|g" |
     sed -e "s|${DOTFILES_PATH:-}|\${DOTFILES_PATH}|g" |
     sed -e "s|${HOME}|\${HOME}|g"
 

--- a/scripts/core/src/dotly.sh
+++ b/scripts/core/src/dotly.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 dotly::list_bash_files() {
-  grep --exclude-dir=*template* "#!/usr/bin/env bash" "${SLOTH_PATH:-${DOTLY_PATH:-}}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
-  grep --exclude-dir=*template* "#!/usr/bin/env sloth" "${SLOTH_PATH:-${DOTLY_PATH:-}}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
-  grep --exclude-dir=*template* "#!/bin/bash" "${SLOTH_PATH:-${DOTLY_PATH:-}}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
-  find "${SLOTH_PATH:-${DOTLY_PATH:-}}"/{bin,dotfiles_template,scripts,shell} -type f -name "*.sh" -not \( -path "*/scripts/*/src/template*/" -and -path "*/scripts/self" \) -print0 2> /dev/null | xargs -0 -I _ echo _ | grep -v "/shell/zsh"
+  grep --exclude-dir=*template* "#!/usr/bin/env bash" "${SLOTH_PATH:-}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
+  grep --exclude-dir=*template* "#!/usr/bin/env sloth" "${SLOTH_PATH:-}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
+  grep --exclude-dir=*template* "#!/bin/bash" "${SLOTH_PATH:-}"/{bin,dotfiles_template,scripts,shell,installer,restorer} -R | awk -F':' '{print $1}' 2> /dev/null | grep -v "/scripts/self/"
+  find "${SLOTH_PATH:-}"/{bin,dotfiles_template,scripts,shell} -type f -name "*.sh" -not \( -path "*/scripts/*/src/template*/" -and -path "*/scripts/self" \) -print0 2> /dev/null | xargs -0 -I _ echo _ | grep -v "/shell/zsh"
 }
 
 dotly::list_dotfiles_bash_files() {

--- a/scripts/core/src/files.sh
+++ b/scripts/core/src/files.sh
@@ -79,12 +79,12 @@ files::fzf() {
 
         if [[ ${#preview_args[@]} -gt 0 ]]; then
           preview_args=(
-            ". \"${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh\";"
+            ". \"${SLOTH_PATH:-}/scripts/core/src/_main.sh\";"
             "${preview_args[@]};"
           )
         else
           preview_args=(
-            ". \"${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh\";"
+            ". \"${SLOTH_PATH:-}/scripts/core/src/_main.sh\";"
           )
         fi
         shift
@@ -101,7 +101,7 @@ files::fzf() {
         done
 
         preview_args=(
-          ". \"${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh\";"
+          ". \"${SLOTH_PATH:-}/scripts/core/src/_main.sh\";"
           "${libraries_to_load[@]}"
           "${preview_args[@]}"
         )

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -4,18 +4,18 @@ DOTFILES_PACKAGE_MANAGERS_PATH="${DOTFILES_PACKAGE_MANAGERS_PATH:-${DOTFILES_PAT
 
 if [[ -n "${PACKAGE_MANAGERS_SRC[*]:-}" ]]; then
   if
-    ! array::exists_value "${SLOTH_PATH:-${DOTLY_PATH:-/dev/null}}/scripts/package/src/package_managers" "${PACKAGE_MANAGERS_SRC[@]}" ||
+    ! array::exists_value "${SLOTH_PATH:-/dev/null}/scripts/package/src/package_managers" "${PACKAGE_MANAGERS_SRC[@]}" ||
       ! array::exists_value "$DOTFILES_PACKAGE_MANAGERS_PATH" "${PACKAGE_MANAGERS_SRC[@]}"
   then
     export PACKAGE_MANAGERS_SRC=(
-      "${SLOTH_PATH:-${DOTLY_PATH:-/dev/null}}/scripts/package/src/package_managers"
+      "${SLOTH_PATH:-/dev/null}/scripts/package/src/package_managers"
       "$DOTFILES_PACKAGE_MANAGERS_PATH"
       "${PACKAGE_MANAGERS_SRC[@]}"
     )
   fi
 else
   export PACKAGE_MANAGERS_SRC=(
-    "${SLOTH_PATH:-${DOTLY_PATH:-/dev/null}}/scripts/package/src/package_managers"
+    "${SLOTH_PATH:-/dev/null}/scripts/package/src/package_managers"
     "$DOTFILES_PACKAGE_MANAGERS_PATH"
   )
 fi

--- a/scripts/core/src/registry.sh
+++ b/scripts/core/src/registry.sh
@@ -6,7 +6,7 @@ DOTFILES_RECIPES_PATH="${DOTFILES_RECIPES_PATH:-${DOTFILES_PATH:-${HOME}/.dotfil
 export SLOTH_RECIPE_PATHS=(
   "${SLOTH_RECIPES_PATH[@]:-}"
   "${DOTFILES_PATH:-${HOME}/.dotfiles}/package/recipes"
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/package/src/recipes"
+  "${SLOTH_PATH:-}/scripts/package/src/recipes"
 )
 
 #;

--- a/scripts/core/src/script.sh
+++ b/scripts/core/src/script.sh
@@ -14,7 +14,7 @@ script::depends_on() {
     has_to_install=$(output::question "\`$non_existing_command\` is a dependency of this script. Should this be installed? [Y/n]")
 
     if output::answer_is_yes "$has_to_install"; then
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add "$non_existing_command"
+      "${SLOTH_PATH:-}/bin/dot" package add "$non_existing_command"
     else
       output::write "🙅‍ The script can't be ran without \`$non_existing_command\` being installed before."
       exit 1

--- a/scripts/core/src/sloth_update.sh
+++ b/scripts/core/src/sloth_update.sh
@@ -49,7 +49,7 @@ export SLOTH_DEFAULT_GIT_HTTP_URL SLOTH_DEFAULT_GIT_SSH_URL SLOTH_DEFAULT_REMOTE
 #"
 sloth_update::sloth_repository_set_ready() {
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
 
   # .Sloth were installed using a package manager
@@ -81,7 +81,7 @@ sloth_update::sloth_repository_set_ready() {
 #"
 sloth_update::get_current_version() {
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
 
   # .Sloth were installed using a package manager
@@ -101,7 +101,7 @@ sloth_update::get_current_version() {
 #"
 sloth_update::get_latest_stable_version() {
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
 
   local url="${SLOTH_DEFAULT_URL:-${SLOTH_DEFAULT_GIT_SSH_URL:-git+ssh://git@github.com:gtrabanco/dotSloth.git}}"
@@ -125,7 +125,7 @@ sloth_update::get_latest_stable_version() {
 sloth_update::local_sloth_repository_can_be_updated() {
   local IS_WORKING_DIRECTORY_CLEAN=false HAS_UNPUSHED_COMMITS=false
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
 
   if [[ -f "${SLOTH_FORCE_CURRENT_VERSION_FILE:-${DOTFILES_PATH:-${HOME}}/.sloth_force_current_version}" ]]; then
@@ -160,7 +160,7 @@ sloth_update::local_sloth_repository_can_be_updated() {
 #"
 sloth_update::should_be_updated() {
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
   local -r latest_version=$(sloth_update::get_latest_stable_version)
   local -r current_version=$(sloth_update::get_current_version)
@@ -222,7 +222,7 @@ sloth_update::should_be_updated() {
 sloth_update::exists_migration_script() {
   local -r updated_version="$(sloth_update::get_current_version)"
 
-  [[ -x "${SLOTH_PATH:-${DOTLY_PATH:-}}/migration/${updated_version}" || -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks/${updated_version}.yaml" || -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks/${updated_version}.yml" ]]
+  [[ -x "${SLOTH_PATH:-}/migration/${updated_version}" || -f "${SLOTH_PATH:-}/symlinks/${updated_version}.yaml" || -f "${SLOTH_PATH:-}/symlinks/${updated_version}.yml" ]]
 }
 
 #;
@@ -243,7 +243,7 @@ sloth_update::sloth_update() {
   force_update="${4:-false}"
 
   local -r SLOTH_UPDATE_GIT_ARGS=(
-    -C "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    -C "${SLOTH_PATH:-}"
   )
 
   # .Sloth were installed using a package manager
@@ -342,8 +342,8 @@ sloth_update::async() {
 
   elif
     ! [[ ${SLOTH_ENV:0:1} =~ ^[dD]$ ]] &&
-      [[ -d "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] &&
-      files::check_if_path_is_older "${SLOTH_PATH:-${DOTLY_PATH:-}}" "${SLOTH_AUTO_UPDATE_PERIOD_IN_DAYS:-7}" "days"
+      [[ -d "${SLOTH_PATH:-}" ]] &&
+      files::check_if_path_is_older "${SLOTH_PATH:-}" "${SLOTH_AUTO_UPDATE_PERIOD_IN_DAYS:-7}" "days"
   then
     if
       sloth_update::local_sloth_repository_can_be_updated &&

--- a/scripts/init/src/init.sh
+++ b/scripts/init/src/init.sh
@@ -7,7 +7,7 @@ fi
 
 # PR annotation
 # If you change this folders you should also change them in init-dotly.sh
-SLOTH_INIT_SCRIPTS_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init.scripts"
+SLOTH_INIT_SCRIPTS_PATH="${SLOTH_PATH:-}/shell/init.scripts"
 DOTFILES_INIT_SCRIPTS_PATH="${DOTFILES_INIT_SCRIPTS_PATH:-$DOTFILES_PATH/shell/init.scripts}"
 ENABLED_INIT_SCRIPTS_PATH="${ENABLED_INIT_SCRIPTS_PATH:-$DOTFILES_PATH/shell/init.scripts-enabled}"
 

--- a/scripts/package/src/recipes/nvm.sh
+++ b/scripts/package/src/recipes/nvm.sh
@@ -6,7 +6,7 @@ nvm::install_script() {
 }
 
 nvm::finish_install() {
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init.scripts/nvm"
+  . "${SLOTH_PATH:-}/shell/init.scripts/nvm"
   nvm install --lts --latest-npm
   sleep 1s
   nvm use --lts
@@ -28,7 +28,7 @@ nvm::is_installed() {
   fi
   export NVM_DIR
 
-  [[ -s "${NVM_DIR}/nvm.sh" ]] && \. "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init.scripts/nvm" && platform::command_exists nvm
+  [[ -s "${NVM_DIR}/nvm.sh" ]] && \. "${SLOTH_PATH:-}/shell/init.scripts/nvm" && platform::command_exists nvm
 }
 
 nvm::install() {
@@ -45,7 +45,7 @@ nvm::install() {
 
   if nvm::is_installed && [[ -z "${DOTFILES_PATH:-}" ]]; then
     nvm::finish_install
-    ln -sf "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init.scripts/nvm" "${DOTFILES_PATH:-/dev/null}/shell/init.scripts-enabled/nvm"
+    ln -sf "${SLOTH_PATH:-}/shell/init.scripts/nvm" "${DOTFILES_PATH:-/dev/null}/shell/init.scripts-enabled/nvm"
   elif nvm::is_installed; then
     nvm::finish_install
     output::empty_line
@@ -56,7 +56,7 @@ nvm::install() {
     output::empty_line
   fi
 
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init.scripts/nvm"
+  . "${SLOTH_PATH:-}/shell/init.scripts/nvm"
 
   nvm::is_installed &&
     output::solution "Nvm, node, npm and npx installed" &&

--- a/shell/bash/init.sh
+++ b/shell/bash/init.sh
@@ -32,7 +32,7 @@ if [[ -n "${DOTFILES_PATH:-}" && -d "$DOTFILES_PATH/shell/bash/themes" ]]; then
   )
 fi
 themes_paths+=(
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/bash/themes"
+  "${SLOTH_PATH:-}/shell/bash/themes"
 )
 
 # brew Bash completion & completions
@@ -60,7 +60,7 @@ done
 PROMPT_COMMAND="__right_prompt"
 export THEME_COMMAND PROMPT_COMMAND
 
-for completion in $(find "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/bash/completions/" "${DOTFILES_PATH:-/dev/null}/shell/bash/completions/" -name "_*" -print0 -exec echo {} \; 2> /dev/null | xargs -0 -I _ echo _); do
+for completion in $(find "${SLOTH_PATH:-}/shell/bash/completions/" "${DOTFILES_PATH:-/dev/null}/shell/bash/completions/" -name "_*" -print0 -exec echo {} \; 2> /dev/null | xargs -0 -I _ echo _); do
   [[ -z "$completion" ]] && continue
   #shellcheck source=/dev/null
   . "$completion" || echo -e "\033[0;31mBASH completion '$completion' could not be loaded\033[0m"

--- a/shell/init-sloth.sh
+++ b/shell/init-sloth.sh
@@ -37,12 +37,12 @@ function recent_dirs() {
 
 function dot::undot() {
   [[ -z "${DOTLY_PATH:-}" ]] && return 1
-  PATH="$(echo "$PATH" | sed -E "s|:${SLOTH_PATH:-${DOTLY_PATH:-}}/bin||g")"
+  PATH="$(echo "$PATH" | sed -E "s|:${SLOTH_PATH:-}/bin||g")"
   printf 'export PATH="%s"' "${PATH//::/:}"
 }
 
 function dot::dotback() {
-  printf 'export PATH="%s/bin:%s"' "${SLOTH_PATH:-${DOTLY_PATH:-}}" "${PATH//::/:}"
+  printf 'export PATH="%s/bin:%s"' "${SLOTH_PATH:-}" "${PATH//::/:}"
 }
 
 ##### Start of Homebrew Installation Patch #####
@@ -53,16 +53,16 @@ function dot::dotback() {
 # Advise no vars defines
 if [ -z "${DOTFILES_PATH:-}" ] ||
   [ ! -d "${DOTFILES_PATH:-}" ] ||
-  [ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ] ||
-  [ ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]; then
+  [ -z "${SLOTH_PATH:-}" ] ||
+  [ ! -d "${SLOTH_PATH:-}" ]; then
   if [[ -d "$HOME/.dotfiles" && -d "${HOME}/.dotfiles/modules/dotly" ]]; then
     DOTFILES_PATH="${HOME}/.dotfiles"
     SLOTH_PATH="${DOTFILES_PATH}/modules/dotly"
-    DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    DOTLY_PATH="${SLOTH_PATH:-}"
   elif [[ -d "${HOME}/.dotfiles" && -d "${HOME}/.dotfiles/modules/sloth" ]]; then
     DOTFILES_PATH="${HOME}/.dotfiles"
     SLOTH_PATH="${DOTFILES_PATH}/modules/sloth"
-    DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
+    DOTLY_PATH="${SLOTH_PATH:-}"
   elif ! ${HOMBREW_SLOTH:-false}; then
     echo -e "\033[0;31m\033[1mDOTFILES_PATH or SLOTH_PATH is not defined or is wrong, .Sloth will fail\033[0m"
   fi
@@ -78,9 +78,9 @@ SLOTH_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
 DOTLY_PATH="${DOTLY_PATH:-${SLOTH_PATH:-}}"
 
 # Sloth aliases and functions
-alias dotly='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
-alias lazy='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
-alias s='"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"'
+alias dotly='"${SLOTH_PATH:-}/bin/dot"'
+alias lazy='"${SLOTH_PATH:-}/bin/dot"'
+alias s='"${SLOTH_PATH:-}/bin/dot"'
 alias undot='eval "$(dot::undot)"'
 alias dotback='eval "$(dot::dotback)"'
 
@@ -255,8 +255,8 @@ path+=($(command -p getconf PATH | command -p tr ':' '\n'))
 { [[ "${DOTLY_ENV:-PROD}" == "CI" ]] && echo ".Sloth initializer: End PATHs"; } || true
 ###### END OF PATHS ######
 ###### Load dotly core for your current BASH ######
-if [[ -n "$SLOTH_SHELL" && -r "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/${SLOTH_SHELL}/init.sh" ]]; then
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/${SLOTH_SHELL}/init.sh" || echo ".Sloth initializer: SHELL ($SLOTH_SHELL) initializer failed"
+if [[ -n "$SLOTH_SHELL" && -r "${SLOTH_PATH:-}/shell/${SLOTH_SHELL}/init.sh" ]]; then
+  . "${SLOTH_PATH:-}/shell/${SLOTH_SHELL}/init.sh" || echo ".Sloth initializer: SHELL ($SLOTH_SHELL) initializer failed"
 else
   printf "\033[0;31m\033[1mDOTLY Could not be loaded: Initializer not found for \`%s\`\033[0m\n" "${SLOTH_SHELL}"
 fi
@@ -277,7 +277,7 @@ fi
 ###### End of load nix package manager if available ######
 
 ###### .Sloth bin path first & Remove duplicated PATHs ######
-PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}/bin:$PATH"
+PATH="${SLOTH_PATH:-}/bin:$PATH"
 
 # Remove duplicated PATH's
 #shellcheck disable=SC2016


### PR DESCRIPTION
## Refactor #255 — Reconcile DOTLY_PATH and SLOTH_PATH

Closes #255.

### Approach: Option A — Single canonical variable

`SLOTH_PATH` is the canonical variable. All `${SLOTH_PATH:-${DOTLY_PATH:-}}`
fallback patterns replaced with `${SLOTH_PATH:-}`. The compatibility layer
in `shell/init-sloth.sh` (lines 76-78) is preserved — it still sets
`SLOTH_PATH` from `DOTLY_PATH` if the former is unset, maintaining backward
compatibility for users who still set `DOTLY_PATH` in their shell config.

### Changes

53 replacements across 13 files:

| File | Changes |
|------|---------|
| `shell/init-sloth.sh` | 10 replacements (compat layer at L76-78 preserved) |
| `scripts/core/src/sloth_update.sh` | 9 |
| `scripts/core/src/dot.sh` | 8 |
| `scripts/package/src/recipes/nvm.sh` | 4 |
| `scripts/core/src/dotly.sh` | 4 |
| `scripts/core/src/package.sh` | 3 |
| `scripts/core/src/files.sh` | 3 |
| `dotfiles_template/shell/aliases.sh` | 3 |
| `shell/bash/init.sh` | 2 |
| `scripts/init/src/init.sh` | 1 |
| `scripts/core/src/script.sh` | 1 |
| `scripts/core/src/registry.sh` | 1 |
| `scripts/core/src/_main.sh` | 1 |

### Verification
- `bash scripts/self/static_analysis` ✅
- `bash scripts/self/lint` ✅
- `make test` ✅ (48/48)

### Note
This is a tech-debt refactor, not a bug fix. Marked as **manual review required**
before merge. The change is mechanically simple (search-and-replace) but the
surface area is wide (13 files, 53 changes).