### PR TITLE
fix(path): replace DOTLY_PATH fallback with canonical SLOTH_PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: ZSH Speed test
         run: |
           echo "DOTFILES_PATH: $DOTFILES_PATH"
-          echo "SLOTH_PATH: ${SLOTH_PATH:-${DOTLY_PATH:-}}"
+          echo "SLOTH_PATH: ${SLOTH_PATH:-}"
           echo "ZIM_HOME: $ZIM_HOME"
           ! command -v zsh &>/dev/null && echo "ZSH Shell not found" && exit
           zsh -c ". \"$HOME/.dotfiles/modules/sloth/shell/init-sloth.sh\"; \"${SLOTH_PATH}/bin/dot\" shell zsh test_performance | tee -a \"${HOME}/dotly.log\""
@@ -60,7 +60,7 @@ jobs:
       - name: BASH Speed test
         run: |
           echo "DOTFILES_PATH: $DOTFILES_PATH"
-          echo "SLOTH_PATH: ${SLOTH_PATH:-${DOTLY_PATH:-}}"
+          echo "SLOTH_PATH: ${SLOTH_PATH:-}"
           echo "ZIM_HOME: $ZIM_HOME"
           ! command -v bash &>/dev/null && echo "BASH Shell not found" && exit
           bash -c ". \"$HOME/.dotfiles/modules/sloth/shell/init-sloth.sh\"; \"${SLOTH_PATH}/bin/dot\" shell bash test_performance | tee -a \"${HOME}/dotly.log\""
@@ -81,6 +81,7 @@ jobs:
 
       - name: Set needed environment variables
         run: |
+          echo "SLOTH_PATH=$PWD" >> $GITHUB_ENV
           echo "DOTLY_PATH=$PWD" >> $GITHUB_ENV
 
       - name: 💿 Static analysis
@@ -98,6 +99,7 @@ jobs:
 
       - name: Set needed environment variables
         run: |
+          echo "SLOTH_PATH=$PWD" >> $GITHUB_ENV
           echo "DOTLY_PATH=$PWD" >> $GITHUB_ENV
           echo "PATH=$PATH:$HOME/go/bin" >> $GITHUB_ENV
 

--- a/bin/dot
+++ b/bin/dot
@@ -20,7 +20,7 @@ if [[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}
     DOTLY_PATH="$SLOTH_PATH"
   fi
 
-  if [[ ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -x "${SLOTH_PATH}/bin/dot" ]]; then
+  if [[ ! -d "${SLOTH_PATH:-}" || ! -x "${SLOTH_PATH}/bin/dot" ]]; then
     echo "Error: Could not find the .Sloth source code."
     exit 1
   fi
@@ -32,10 +32,10 @@ if [[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}
   export SLOTH_PATH DOTLY_PATH
 fi
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && echo "Error: Could not find where the .Sloth is installed." && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && echo "Error: Could not find where the .Sloth is installed." && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Execute lazy scripts in your dotfiles
 ##?
@@ -86,22 +86,22 @@ elif [[ "${1:-}" == "-l" || "${1:-}" == "--latest" ]]; then
 
 # Self-update of .Sloth
 elif [[ "${1:-}" == "self-update" || "${1:-}" == "update" ]] && args::total_is 1 "$@"; then
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core update
+  "${SLOTH_PATH:-}/bin/dot" core update
   exit
 
 # Autoupdate (Async update)
 elif [[ "${1:-}" == "async-update" ]] && args::total_is 1 "$@"; then
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core update --async
+  "${SLOTH_PATH:-}/bin/dot" core update --async
   exit
 
 # Get PATH to .Sloth
 elif [[ "${1:-}" == "--prefix" ]] && args::total_is 1 "$@"; then
-  echo "${SLOTH_PATH:-${DOTLY_PATH:-}}"
+  echo "${SLOTH_PATH:-}"
   exit
 
 # Get Loader ready to use with
 elif [[ "${1:-}" == "shellenv" ]] && args::total_is 1 "$@"; then
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core loader shellenv
+  "${SLOTH_PATH:-}/bin/dot" core loader shellenv
   exit
 fi
 
@@ -121,7 +121,7 @@ fzf_prompt() {
   printf "%s" "$script"
   read -r args
 
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" "${script}" "${args}"
+  "${SLOTH_PATH:-}/bin/dot" "${script}" "${args}"
 }
 
 script_exist() {
@@ -143,7 +143,7 @@ else
 
   script_path=""
   [[ -n "${DOTFILES_PATH:-}" ]] && script_exist "${DOTFILES_PATH}" "${context}" "${script}" && script_path="${DOTFILES_PATH}"
-  script_exist "${SLOTH_PATH:-${DOTLY_PATH:-}}" "$context" "$script" && script_path="${SLOTH_PATH:-${DOTLY_PATH:-}}"
+  script_exist "${SLOTH_PATH:-}" "$context" "$script" && script_path="${SLOTH_PATH:-}"
 
   if [[ -z "$script_path" ]]; then
     output::error "The script <$context / $script> doesn't exist"
@@ -176,7 +176,7 @@ else
       grep -q "/scripts/self/src/_main.sh" "${script_full_path}"
   then
     #shellcheck disable=SC2098,SC2097
-    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "$script_full_path" "$@"
+    SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-}" DOTFILES_PATH="${DOTFILES_PATH:-}" "$script_full_path" "$@"
   else
     if ! grep -q "IGNORE_DOCOPT" "$script_full_path" || ! grep -q "IGNORE_DOCPARS" "$script_full_path"; then
       docs::parse "$script_full_path" "$@"

--- a/bin/sloth
+++ b/bin/sloth
@@ -29,7 +29,7 @@ elif [[ "$firstarg" == "-v" || "$firstarg" == "--version" ]]; then
   exit
 elif [[ ! -x "$script_full_path" ]]; then
   #shellcheck disable=SC2097,SC2098
-  SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}" DOTFILES_PATH="${DOTFILES_PATH:-}" "${SLOTH_PATH}/bin/dot" "$@"
+  SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-}" DOTFILES_PATH="${DOTFILES_PATH:-}" "${SLOTH_PATH}/bin/dot" "$@"
   exit $?
 fi
 

--- a/bin/up
+++ b/bin/up
@@ -28,7 +28,7 @@ if ${split:-false}; then
   script::depends_on tmux
   SESSION_NAME="${SESSION_NAME:-$(date +%s)}"
   #shellcheck disable=SC2016
-  tmux new-session -s "$SESSION_NAME" "SESSION_NAME='${SESSION_NAME}' '${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot' package update_all ${package_managers[*]:-}" \; split-window -h 'tail -f ${HOME}/dotly.log' \; || true
+  tmux new-session -s "$SESSION_NAME" "SESSION_NAME='${SESSION_NAME}' '${SLOTH_PATH:-}/bin/dot' package update_all ${package_managers[*]:-}" \; split-window -h 'tail -f ${HOME}/dotly.log' \; || true
   exit 0
 fi
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -29,7 +29,7 @@ This is not a layered architecture in the traditional sense; it's a command-disp
 - **Context scripts must source `_main.sh` first** before using any core library function. The standard header is:
   ```bash
   #shellcheck disable=SC1091
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+  . "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
   ```
 - **The `installer` and `restorer` scripts must be self-contained** — they run before dotSloth is installed and must not depend on `scripts/core/src/` or any `SLOTH_PATH` resolution.
 - **Package manager wrappers** (`scripts/package/src/package_managers/*.sh`) must implement the standard interface: `dump`, `install`, `update_all`, `cleanup`, `which` (where applicable). New wrappers must follow the `brew.sh` pattern.

--- a/docs/fix/266-complete-path-fallback-refactor/SPEC.md
+++ b/docs/fix/266-complete-path-fallback-refactor/SPEC.md
@@ -1,0 +1,224 @@
+# fix/266-complete-path-fallback-refactor
+
+> Fix specification. Copy this folder to `docs/fix/<issue-number>-<topic>/`, fill
+> every section, and register the entry in `docs/fix/README.md`. Lighter than a
+> feature spec — no planning artifacts. The SPEC alone is the source of truth.
+
+## Goal
+
+Complete the DOTLY_PATH fallback refactor started in #255: replace 139 remaining
+occurrences of `${SLOTH_PATH:-${DOTLY_PATH:-}}` with `${SLOTH_PATH:-}` in 54 files.
+The fallback is redundant because `_main.sh` (line 8-10) and `init-sloth.sh`
+(line 76-78) already resolve `SLOTH_PATH` from `DOTLY_PATH` before any downstream
+code runs. The architecture doc must also be updated to reflect the canonical
+pattern.
+
+## Issue
+
+`#266` — tracked issue. Required. The PR must close it.
+
+## Branch
+
+`fix/266-complete-path-fallback-refactor`
+
+## Root cause
+
+Issue #255 refactored 53 occurrences in 13 core library files but left 139
+occurrences in 54 context scripts, standalone scripts, entry points, shell
+integration files, and templates. These files still use the dual-variable
+fallback pattern `${SLOTH_PATH:-${DOTLY_PATH:-}}` even though:
+
+1. `scripts/core/src/_main.sh:8-10` — early resolution block resolves both
+   variables from each other before any library is loaded.
+2. `shell/init-sloth.sh:76-78` — compatibility layer resolves both variables
+   before sourcing shell integration files.
+3. `bin/dot:12-20` — entry point resolves `SLOTH_PATH` from `realpath` if unset,
+   then sources `_main.sh`.
+4. `bin/sloth:10` — entry point checks `SLOTH_PATH` and sources `_main.sh`.
+
+Evidence:
+- `grep -rc 'SLOTH_PATH:-${DOTLY_PATH' scripts/ bin/ restorer installer shell/ dotfiles_template/` → 139 occurrences in 54 files
+- `scripts/core/src/_main.sh:8-10` — `SLOTH_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"` / `DOTLY_PATH="${DOTLY_PATH:-${SLOTH_PATH:-}}"`
+- `shell/init-sloth.sh:76-78` — same resolution block
+- `docs/architecture/ARCHITECTURE.md:32` — still references stale pattern
+
+## Scope
+
+### In scope
+
+The smallest change set that closes the issue.
+
+1. Replace `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` in 54 files
+   across `scripts/`, `bin/`, `restorer`, `installer`, `shell/`,
+   `dotfiles_template/`.
+2. Update `docs/architecture/ARCHITECTURE.md:32` — replace stale pattern with
+   canonical `${SLOTH_PATH:-}`.
+3. Run `shfmt` on all modified files to ensure formatting compliance.
+
+### Out of scope
+
+- `shell/init-sloth.sh:76-78` — compatibility layer, already preserved in #255.
+- `scripts/core/src/_main.sh:8-10` — early resolution block, added in #255.
+- `dotfiles_template/README.md` — documentation reference, not code. The
+  fallback pattern in the README is illustrative for users setting up manually.
+  Pointer: update in a separate docs cleanup if needed.
+- Adding `set -euo pipefail` to scripts that lack it — tracked in #269.
+
+## Impact
+
+- Modules/files touched: 54 files across `scripts/`, `bin/`, `restorer`,
+  `installer`, `shell/`, `dotfiles_template/`, plus `docs/architecture/ARCHITECTURE.md`.
+- Blast radius: medium — touches entry points (`bin/dot`, `bin/sloth`, `bin/up`),
+  context scripts, shell integration, and bootstrap scripts (`restorer`,
+  `installer`). If `SLOTH_PATH` is not resolved before these files run, they will
+  fail. However, all files either (a) source `_main.sh` first, (b) are loaded by
+  `init-sloth.sh` which resolves it, or (c) are entry points that resolve it
+  themselves.
+- Detection lead time: immediate — broken `SLOTH_PATH` resolution would cause
+  `bin/dot` to fail on every invocation.
+
+## Rules that must never be violated
+
+- `bin/dot` and `bin/sloth` are entry points that resolve `SLOTH_PATH` before
+  sourcing `_main.sh`. The fallback pattern in these files handles the case where
+  neither variable is set — the entry point resolves it from `realpath`. After
+  the entry point resolves `SLOTH_PATH`, the fallback is redundant. BUT: the
+  fallback in the entry point's initial check (`if [[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]]`)
+  must be preserved until AFTER the resolution block, because at that point
+  neither variable may be set. Only the fallback in lines AFTER the resolution
+  block should be replaced.
+- `restorer` and `installer` are standalone scripts that resolve `SLOTH_PATH`
+  themselves (lines 324-325 and 313-314). The fallback in lines BEFORE the
+  resolution block must be preserved. Only lines AFTER should be replaced.
+- `shell/init-sloth.sh:76-78` must NOT be modified (compatibility layer).
+- `scripts/core/src/_main.sh:8-10` must NOT be modified (early resolution block).
+- `shfmt` formatting: `shfmt -ln bash -sr -ci -i 2 -d` must pass.
+- `shellcheck` static analysis must pass.
+
+## Risks
+
+- **Operational**: `restorer` and `installer` are bootstrap scripts that run
+  before `_main.sh` is available. They resolve `SLOTH_PATH` themselves. If the
+  fallback is removed from lines BEFORE their resolution block, they will fail
+  on systems where neither `SLOTH_PATH` nor `DOTLY_PATH` is set. Mitigation:
+  only replace fallback in lines AFTER the resolution block in these files.
+- **Operational**: `dotfiles_template/` files are copied to user dotfiles. They
+  may run in contexts where `init-sloth.sh` has not yet resolved `SLOTH_PATH`
+  (e.g. a user manually running a script before sourcing `.zshrc`). Mitigation:
+  `dotfiles_template/bin/sdot` sources `.bashrc` first (which loads
+  `init-sloth.sh`), `dotfiles_template/scripts/hello/world` sources `_main.sh`
+  first. Both are safe to refactor.
+- **Security**: n/a — no auth, secrets, or PII.
+- **Compliance**: n/a.
+
+## Acceptance criteria
+
+- [ ] 0 occurrences of `${SLOTH_PATH:-${DOTLY_PATH:-}}` remain in `scripts/`,
+      `bin/`, `shell/` (excluding `init-sloth.sh:76-78`)
+- [ ] `restorer` and `installer` fallback patterns replaced only AFTER their
+      resolution blocks (lines 324-325 and 313-314 respectively)
+- [ ] `docs/architecture/ARCHITECTURE.md:32` updated to canonical `${SLOTH_PATH:-}`
+- [ ] `shell/init-sloth.sh:76-78` unchanged (compatibility layer)
+- [ ] `scripts/core/src/_main.sh:8-10` unchanged (early resolution block)
+- [ ] `bash scripts/self/static_analysis` passes clean
+- [ ] `dot core lint` passes clean
+- [ ] `make test` passes (48+ existing tests)
+- [ ] CI env simulation passes: `env -u SLOTH_PATH DOTLY_PATH=<repo> bash scripts/self/static_analysis`
+- [ ] Manual verification: `bin/dot --help` works with only `DOTLY_PATH` set
+
+## Rollback
+
+Revert the PR. No data-side cleanup needed — the refactor only changes variable
+reference patterns, no state is modified.
+
+## Effort
+
+**S** — 54 files, mechanical replacement with 2 exceptions (restorer/installer
+pre-resolution lines). ≤ 4h including verification.
+
+## Impact (extra sections)
+
+- Layers: all layers — entry points, context scripts, shell integration,
+  bootstrap scripts, templates.
+- Blast radius: medium — touches critical paths but the resolution blocks
+  already handle the fallback.
+- Detection lead time: immediate — any broken path resolution fails on first
+  invocation.
+
+## Rules that must never be violated (extra)
+
+- `bin/dot` and `bin/sloth` entry points: preserve fallback in the initial check
+  (before resolution block), replace in lines after.
+- `restorer` and `installer`: preserve fallback before their resolution blocks
+  (lines 324-325 and 313-314), replace after.
+- `shell/init-sloth.sh:76-78` and `_main.sh:8-10` — DO NOT MODIFY.
+- `shfmt -ln bash -sr -ci -i 2 -d` must pass on all modified files.
+- `shellcheck` must pass (CI env: `DOTLY_PATH` set, `SLOTH_PATH` unset).
+
+## Operational risks
+
+- `restorer`/`installer` run before `_main.sh` — must preserve pre-resolution
+  fallback.
+- `dotfiles_template/` files run in user environments — verified safe (all source
+  `_main.sh` or `.bashrc` first).
+- CI sets `DOTLY_PATH` only (not `SLOTH_PATH`) — `_main.sh` resolves it. Must
+  verify with `env -u SLOTH_PATH DOTLY_PATH=<repo>`.
+
+## Security risks
+
+n/a — no auth, secrets, PII, or webhooks.
+
+## Compliance touchpoints
+
+n/a.
+
+## Affected docs
+
+- `docs/architecture/ARCHITECTURE.md` — section "Context scripts must source
+  `_main.sh` first": replace `${SLOTH_PATH:-${DOTLY_PATH:-}}` with `${SLOTH_PATH:-}`.
+- `docs/fix/README.md` — update entry status from `pending` to `done` when PR opens.
+
+## Observability
+
+- Before: scripts use `${SLOTH_PATH:-${DOTLY_PATH:-}}` (dual fallback).
+- After: scripts use `${SLOTH_PATH:-}` (single canonical variable).
+- Failure mode: if `SLOTH_PATH` is not resolved, scripts fail immediately with
+  "file not found" — detectable on first run.
+
+## Cross-issue notes
+
+- #255 — prerequisite, already merged. This fix completes the refactor.
+- #269 (set -euo pipefail migration) — parallel, no overlap. Some files in #266
+  may also be in #269, but the changes are independent (variable reference vs
+  shell options).
+- #265 (gem false positive) — parallel, no overlap (different file).
+
+## Effort
+
+**S** — 54 files, mechanical replacement with 2 exceptions. ≤ 4h.
+
+## Decisions made during drafting
+
+- `dotfiles_template/README.md` — left out of scope. It's documentation showing
+  users how to manually install. The fallback pattern is illustrative.
+- `dotfiles_template/bin/sdot` — safe to refactor: sources `.bashrc` first which
+  loads `init-sloth.sh` which resolves `SLOTH_PATH`.
+- `dotfiles_template/scripts/hello/world` — safe to refactor: sources `_main.sh`
+  first.
+- `dotfiles_template/shell/zsh/.zshrc` — safe to refactor: loads `init-sloth.sh`
+  which resolves `SLOTH_PATH`.
+- `bin/up` — uses `#!/usr/bin/env sloth` shebang which sources `_main.sh`. Safe
+  to refactor.
+- `shell/bash/completions/_dot` and `shell/zsh/completions/_dot` — loaded by
+  shell after `init-sloth.sh` resolves `SLOTH_PATH`. Safe to refactor.
+- `shell/init.scripts/autoupdate` — loaded by `init-sloth.sh` after resolution.
+  Safe to refactor.
+- `shell/zsh/themes/*` — loaded by zsh prompt system after `init-sloth.sh`.
+  Safe to refactor.
+- `shell/zsh/bindings/dot.zsh` — loaded after `init-sloth.sh`. Safe to refactor.
+- `bin/dot` — preserve fallback in initial check (lines 12-13), replace in lines
+  after resolution block (line 20+).
+- `bin/sloth` — preserve fallback in initial check (line 10), replace in line 12+
+  (after `_main.sh` is sourced).
+- `restorer` — preserve fallback before line 324, replace after.
+- `installer` — preserve fallback before line 313, replace after.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
 | 265-gem-update-false-positive | gem::update_apps silently fails on broken system Ruby | pending | — | [#265](https://github.com/gtrabanco/dotSloth/issues/265) |
-| 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | pending | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
+| 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | done | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
 
 ## Conventions

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
 | 265-gem-update-false-positive | gem::update_apps silently fails on broken system Ruby | pending | — | [#265](https://github.com/gtrabanco/dotSloth/issues/265) |
-| 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | done | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
+| 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | done · [#272](https://github.com/gtrabanco/dotSloth/pull/272) | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
 
 ## Conventions

--- a/dotfiles_template/README.md
+++ b/dotfiles_template/README.md
@@ -27,7 +27,7 @@ git commit -m "Initial comit"
 * Clone your dotfiles repository `git clone [your repository of dotfiles] $HOME/.dotfiles`
 * Go to your dotfiles folder `cd $HOME/.dotfiles`
 * Install git submodules `git submodule update --init --recursive modules/sloth`
-* Install your dotfiles `DOTFILES_PATH="$HOME/.dotfiles" SLOTH_PATH="$DOTFILES_PATH/modules/sloth" "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" self install`
+* Install your dotfiles `DOTFILES_PATH="$HOME/.dotfiles" SLOTH_PATH="$DOTFILES_PATH/modules/sloth" "${SLOTH_PATH:-}/bin/dot" self install`
 * Restart your terminal
 * Import your packages `dot package import`
 

--- a/dotfiles_template/bin/sdot
+++ b/dotfiles_template/bin/sdot
@@ -8,4 +8,4 @@ set -euo pipefail
 ##?
 ##? Same usage as dot
 
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" "$@"
+"${SLOTH_PATH:-}/bin/dot" "$@"

--- a/dotfiles_template/scripts/hello/world
+++ b/dotfiles_template/scripts/hello/world
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##?
 ##?

--- a/dotfiles_template/shell/zsh/.zshrc
+++ b/dotfiles_template/shell/zsh/.zshrc
@@ -2,7 +2,8 @@
 # zmodload zsh/zprof
 
 ###### .Sloth Loader ######
-if [[ -f "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]; then
+if [[ -f "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]
+then
   #shellcheck disable=SC1091
   . "${SLOTH_PATH:-}/shell/init-sloth.sh"
 else

--- a/dotfiles_template/shell/zsh/.zshrc
+++ b/dotfiles_template/shell/zsh/.zshrc
@@ -2,10 +2,9 @@
 # zmodload zsh/zprof
 
 ###### .Sloth Loader ######
-if [[ -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh" ]]
-then
+if [[ -f "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]; then
   #shellcheck disable=SC1091
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh"
+  . "${SLOTH_PATH:-}/shell/init-sloth.sh"
 else
   echo "\033[0;31m\033[1mSLOTH Loader could not be found, check \$DOTFILES_PATH & \$SLOTH_PATH variables\033[0m"
 fi

--- a/installer
+++ b/installer
@@ -385,7 +385,7 @@ git config -f .gitmodules submodule."$dotly_inner_path".ignore dirty
 _a "Installing .Sloth dependencies"
 git submodule update --init --recursive 2>&1 | _log "Installing dependencies"
 
-cd "${SLOTH_PATH:-${DOTLY_PATH:-}}" || true
+cd "${SLOTH_PATH:-}" || true
 
 if [[ ${IS_ICLOUD_DOTFILES:-true} == true ]]; then
   if [[ -d "$DOTFILES_LINK_PATH" ]]; then

--- a/restorer
+++ b/restorer
@@ -504,7 +504,7 @@ _w "Installing .Sloth/Dotly default tools"
 _w "Please be patient this could take some time...🙏"
 # Installing default .Sloth/Dotly tools
 PATH="$PATH:/usr/local/bin:$HOME/.cargo/bin"
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core install || {
+"${SLOTH_PATH:-}/bin/dot" core install || {
   _e ".Sloth/Dotly Could not be installed but your dotfiles are restored. Use:"
   _e "  tail -f $HOME/dotly.log"
   _e "To know what happened and where is the point of failure"
@@ -517,7 +517,7 @@ if ${USER_IMPORT_PACKAGES:-false}; then
   _w "Importing your packages"
   _w "This can take a very long time, be patient...🙏"
   {
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package import --never-prompt 2>&1 | _log "Importing user packages" &&
+    "${SLOTH_PATH:-}/bin/dot" package import --never-prompt 2>&1 | _log "Importing user packages" &&
       _a "Packages imported 👏" &&
       _w
   } || {

--- a/scripts/core/debug
+++ b/scripts/core/debug
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Debug dotly
 ##?

--- a/scripts/core/install
+++ b/scripts/core/install
@@ -13,7 +13,7 @@ if [[ -z "${SLOTH_PATH:-}" ]]; then
 fi
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "install.sh"
 
 start_sudo() {
@@ -43,7 +43,7 @@ has_sudo() {
 }
 
 initilize_sloth_if_necessary() {
-  if ! git::is_in_repo -C "${SLOTH_PATH:-${DOTLY_PATH:-}}" > /dev/null 2>&1; then
+  if ! git::is_in_repo -C "${SLOTH_PATH:-}" > /dev/null 2>&1; then
     output::answer "Initilizing .Sloth as repository"
     sloth_update::sloth_repository_set_ready 2>&1 | log::file "Initilizing .Sloth as repository" || true
     output::empty_line
@@ -52,7 +52,7 @@ initilize_sloth_if_necessary() {
   fi
 
   output::answer "Updating .Sloth submodules"
-  git::git -C "${SLOTH_PATH:-${DOTLY_PATH:-}}" submodule update --init --recursive 2>&1 | log::file "Update .Sloth submodules" || true
+  git::git -C "${SLOTH_PATH:-}" submodule update --init --recursive 2>&1 | log::file "Update .Sloth submodules" || true
   output::empty_line
 }
 
@@ -279,7 +279,7 @@ fi
 
 if [[ -n "$DOTFILES_PATH" ]]; then
   output::answer "Creating dotfiles structure"
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" dotfiles create "$DOTFILES_PATH" | log::file "Creating dotfiles structure" || exit 1
+  "${SLOTH_PATH:-}/bin/dot" dotfiles create "$DOTFILES_PATH" | log::file "Creating dotfiles structure" || exit 1
   output::empty_line
 else
   output::answer "Skipping dotfiles creation"
@@ -292,13 +292,13 @@ if ! ${ignore_symlinks:-false} && ! ${IGNORE_APPLY_SYMLINKS:-false}; then
   output::answer "Setting up symlinks"
   SYMLINKS_ARGS=(--interactive-backup)
   if [[ -z "${DOTFILES_PATH:-}" ]]; then
-    if "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply "${SYMLINKS_ARGS[@]}" --continue-on-error --after-core 2>&1 | log::file "Applying symlinks"; then
+    if "${SLOTH_PATH:-}/bin/dot" symlinks apply "${SYMLINKS_ARGS[@]}" --continue-on-error --after-core 2>&1 | log::file "Applying symlinks"; then
       output::solution "Symlinks applied"
     else
       output::error "All symlinks were applied with errors. Use \`dot self debug\` to see what's wrong"
     fi
   else
-    if "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply "${SYMLINKS_ARGS[@]}" --continue-on-error core 2>&1 | log::file "Applying symlinks"; then
+    if "${SLOTH_PATH:-}/bin/dot" symlinks apply "${SYMLINKS_ARGS[@]}" --continue-on-error core 2>&1 | log::file "Applying symlinks"; then
       output::solution "Symlinks applied"
     else
       output::error "All symlinks were applied with errors. Use \`dot self debug\` to see what's wrong"
@@ -339,7 +339,7 @@ unset SYMLINKS_ARGS bk
 if ! ${ignore_loader}; then
   # Adding .Sloth loader to bashrc and zshrc
   output::answer "Adding .Sloth loader to .bashrc and .zshrc"
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core loader --modify
+  "${SLOTH_PATH:-}/bin/dot" core loader --modify
 fi
 
 # ZSH as default shell if we are using zsh
@@ -376,7 +376,7 @@ if [[ "${DOTLY_ENV:-PROD}" != "CI" ]] && platform::command_exists zsh; then
   output::answer "Installing completions"
 
   {
-    zsh "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" shell zsh reload_completions > /dev/null 2>&1 &&
+    zsh "${SLOTH_PATH:-}/bin/dot" shell zsh reload_completions > /dev/null 2>&1 &&
       output::solution '✅ ZSH Completions realoaded'
   } || output::error '❌ Error reloading completions. Execute later \`dot shell zsh reload_completions\`'
 
@@ -388,7 +388,7 @@ if
     ! ${ignore_link:-false}
 then
   output::answer "Linking dot command for all users in \`${link_prefix}/bin\`"
-  ln -f -s "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" "${link_prefix}/bin/dot"
+  ln -f -s "${SLOTH_PATH:-}/bin/dot" "${link_prefix}/bin/dot"
   [[ -x "${link_prefix}/dot" ]] || output::error "\`dot\` command could not be linked"
   output::empty_line
 fi
@@ -415,17 +415,17 @@ output::answer '🥳 🎉 .Sloth installed sucessfully'
 output::empty_line
 
 output::answer "Trying to load .Sloth"
-if [[ -r "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh" ]]; then
+if [[ -r "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]; then
   output::solution "Loading .Sloth"
   #shellcheck disable=SC1091
-  source "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh" | log::file ".Sloth initiliser" || output::error "Error while loading .Sloth"
+  source "${SLOTH_PATH:-}/shell/init-sloth.sh" | log::file ".Sloth initiliser" || output::error "Error while loading .Sloth"
 
   if [[ "${DOTLY_ENV:-PROD}" == "CI" ]]; then
     echo "$PATH" | tr ':' '\n' | log::file ".Sloth PATH's for Debugging"
 
-    if echo "$PATH" | grep -q "^${SLOTH_PATH:-${DOTLY_PATH:-}}/bin:"; then
-      output::error "You need to add ${SLOTH_PATH:-${DOTLY_PATH:-}}/bin to your PATH at the first place"
-      output::answer "\`export PATH=\"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin:$PATH\"\`"
+    if echo "$PATH" | grep -q "^${SLOTH_PATH:-}/bin:"; then
+      output::error "You need to add ${SLOTH_PATH:-}/bin to your PATH at the first place"
+      output::answer "\`export PATH=\"${SLOTH_PATH:-}/bin:$PATH\"\`"
       exit 1
     fi
   fi
@@ -446,7 +446,7 @@ if ! ${IGNORE_UPDATE_PACKAGES:-false}; then
     output::answer "More info: https://www.gitmemory.com/issue/ruby/openssl/385/656744433"
     output::empty_line
   fi
-  "${SLOTH_PATH:-${DOTLY_PATH}}/bin/dot" package update_all | log::file "Updating all system packages"
+  "${SLOTH_PATH:-}/bin/dot" package update_all | log::file "Updating all system packages"
   output::empty_line
 elif ${IGNORE_UPDATE_PACKAGES:-false}; then
   output::answer "All system packages update aborted by the user"

--- a/scripts/core/lint
+++ b/scripts/core/lint
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "dotly.sh"
 
 ##? Lint all sloth/dotly related bash files
@@ -66,7 +66,7 @@ if [[ -z "${all_files[*]:-}" ]]; then
   if ${dotfiles:-false}; then
     readarray -t all_files < <(dotly::list_dotfiles_bash_files | grep -v "${DOTFILES_PATH}/shell/zsh")
   else
-    readarray -t all_files < <(dotly::list_bash_files | grep -v "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/zsh")
+    readarray -t all_files < <(dotly::list_bash_files | grep -v "${SLOTH_PATH:-}/shell/zsh")
   fi
 fi
 

--- a/scripts/core/loader
+++ b/scripts/core/loader
@@ -8,15 +8,15 @@ set -euo pipefail
 # export SLOTH_PATH="HOMEBREW_PREFIX/opt/dot"
 ##### End of Hombrew Installation Patch #####
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "templating.sh" "core"
 
 # Define DOTFILES_PATH and SLOTH_PATH values in .bashrc and .zshrc
 [[ -n "${DOTFILES_PATH:-}" ]] && DOTFILES_PATH_VALUE="${DOTFILES_PATH//$HOME/\$\{HOME\}}"
-SLOTH_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}"
+SLOTH_PATH="${SLOTH_PATH:-}"
 
 # Standalone install with brew
 if [[ -n "${SLOTH_PATH:-}" && -d "${SLOTH_PATH}" ]]; then
@@ -58,10 +58,10 @@ zshrc_load() {
     "zshrc")
       echo
       echo '###### .Sloth Loader ######'
-      echo 'if [[ -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh" ]]'
+      echo 'if [[ -f "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]'
       echo 'then'
       echo '  #shellcheck disable=SC1091'
-      echo '  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh"'
+      echo '  . "${SLOTH_PATH:-}/shell/init-sloth.sh"'
       echo 'else'
       echo '  echo "\033[0;31m\033[1mSLOTH Loader could not be found, check \$DOTFILES_PATH & \$SLOTH_PATH variables\033[0m"'
       echo 'fi'
@@ -110,10 +110,10 @@ bashrc_load() {
     "loader")
       echo
       echo '###### .Sloth Loader ######'
-      echo 'if [[ -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh" ]]'
+      echo 'if [[ -f "${SLOTH_PATH:-}/shell/init-sloth.sh" ]]'
       echo 'then'
       echo '  #shellcheck disable=SC1091'
-      echo '  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/init-sloth.sh"'
+      echo '  . "${SLOTH_PATH:-}/shell/init-sloth.sh"'
       echo 'else'
       echo '  echo "\033[0;31m\033[1mSLOTH Loader could not be found, check \$DOTFILES_PATH & \$SLOTH_PATH variables\033[0m"'
       echo 'fi'

--- a/scripts/core/migration
+++ b/scripts/core/migration
@@ -2,10 +2,10 @@
 
 set -uo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "templating.sh" "core"
 
 ##?  Executes migration scripts for dotfiles. If your dotly is updated and no
@@ -51,10 +51,10 @@ then
   fi
 
 elif [[ -z "${to_version:-}" ]]; then
-  to_version="$(find "${SLOTH_PATH:-${DOTLY_PATH:-}}/migration/" -name "*" -type f,l -executable -print0 | xargs -0 -I _ basename _ | sort --reverse | fzf --header "Select migration script version")"
+  to_version="$(find "${SLOTH_PATH:-}/migration/" -name "*" -type f,l -executable -print0 | xargs -0 -I _ basename _ | sort --reverse | fzf --header "Select migration script version")"
 fi
 
-if [[ -n "$to_version" ]] && [[ -x "${SLOTH_PATH:-${DOTLY_PATH:-}}/migration/${to_version}" ]]; then
+if [[ -n "$to_version" ]] && [[ -x "${SLOTH_PATH:-}/migration/${to_version}" ]]; then
   output::write "You will execute migration script for \`${to_version}\` this could"
   output::write "result in a damage of your current dotfiles if they are not"
   output::write "organized as expected."
@@ -65,14 +65,14 @@ if [[ -n "$to_version" ]] && [[ -x "${SLOTH_PATH:-${DOTLY_PATH:-}}/migration/${t
   output::empty_line
 
   #shellcheck source=/dev/null
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/migration/${to_version}" || output::error "Migration script '${to_version}' could not be executed"
+  . "${SLOTH_PATH:-}/migration/${to_version}" || output::error "Migration script '${to_version}' could not be executed"
 else
   output::error "There is no migration script for version '${to_version}' or is not a executable file"
 fi
 
-if [[ -n "$to_version" ]] && { [[ -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks/${to_version}.yaml" ]] || [[ -f "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks/${to_version}.yml" ]]; }; then
+if [[ -n "$to_version" ]] && { [[ -f "${SLOTH_PATH:-}/symlinks/${to_version}.yaml" ]] || [[ -f "${SLOTH_PATH:-}/symlinks/${to_version}.yml" ]]; }; then
   output::header "Applying symlinks for '${to_version}'"
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks update "${to_version}"
+  "${SLOTH_PATH:-}/bin/dot" symlinks update "${to_version}"
 fi
 
 # If migration script is executed then finalize the update

--- a/scripts/core/raycast
+++ b/scripts/core/raycast
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/output.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/output.sh"
 
 ##? Link Raycast scripts for .Sloth in your raycastr directory path
 ##?
@@ -26,6 +26,6 @@ docs::parse "$@"
 output::write "This can not be done automatically"
 output::write "1. Open Raycast Preferences > Extensions"
 output::write "2. Click on the \`+\` icon button and choose \`Add Script Directory\`"
-output::write "3. Adds: \`${SLOTH_PATH:-${DOTLY_PATH:-}}/_raycast\`"
+output::write "3. Adds: \`${SLOTH_PATH:-}/_raycast\`"
 output::empty_line
 output::answer "🥳 🎉 Enjoy"

--- a/scripts/core/static_analysis
+++ b/scripts/core/static_analysis
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "dotly.sh"
 
 # Default value

--- a/scripts/core/update
+++ b/scripts/core/update
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 
 void() {
   return
@@ -79,7 +79,7 @@ fi
 if [[ -f "$DOTFILES_PATH/.sloth_updated" ]]; then
   if sloth_update::exists_migration_script; then
     output::answer "There is a migration script for this version"
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core migration --updated
+    "${SLOTH_PATH:-}/bin/dot" core migration --updated
   fi
 
   output::answer '✅ .Sloth updated to the latest version'

--- a/scripts/core/version
+++ b/scripts/core/version
@@ -3,10 +3,10 @@
 set -uo pipefail
 set +e # Avoid crash if any function return false
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 dot::load_library "templating.sh" "core"
 
 check_local_tag_exists() {

--- a/scripts/core/wrong
+++ b/scripts/core/wrong
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck source=/dev/null
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Something went terribly wrong
 ##?
@@ -23,4 +23,4 @@ set -euo pipefail
 ##?
 #? v1.0.0
 
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/open" "https://www.youtube.com/watch?v=t3otBjVZzT0"
+"${SLOTH_PATH:-}/bin/open" "https://www.youtube.com/watch?v=t3otBjVZzT0"

--- a/scripts/dotfiles/create
+++ b/scripts/dotfiles/create
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "templating.sh" "core"
 
 ##? Create the dotfiles structure
@@ -31,7 +31,7 @@ if ! mkdir -p "$DOTFILES_PATH" 2> /dev/null; then
 fi
 
 if [ ! -d "${DOTFILES_PATH}/shell" ]; then
-  cp -r "${SLOTH_PATH:-${DOTLY_PATH:-}}/dotfiles_template/"* "${DOTFILES_PATH}/"
+  cp -r "${SLOTH_PATH:-}/dotfiles_template/"* "${DOTFILES_PATH}/"
 
   log::success "Done!"
 else

--- a/scripts/generator/bin
+++ b/scripts/generator/bin
@@ -14,7 +14,7 @@
 ##?   -s --sample        Create a script using more complete example with some comments.
 ##?                      useful if it is your first script. Anyway you can see more help
 ##?                      in the docopt website: http://docopt.org
-##?   -c --core          Create the context and script in "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts" instead of
+##?   -c --core          Create the context and script in "${SLOTH_PATH:-}/scripts" instead of
 ##?                      your "$DOTFILES_PATH/scripts" folder
 ##?   -d --dotly         Generate a Dotly compatible script
 ##?   --author <author>  Provide who is the author, if none the default git author will

--- a/scripts/generator/package_manager
+++ b/scripts/generator/package_manager
@@ -46,11 +46,11 @@ if ${core:-false}; then
   output::error "WARNING! You will create the package manager in .Sloth core path"
   ! output::yesno "Are you sure you want to continue" && exit 1
 
-  [[ ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/package/src/package_managers/" ]] &&
+  [[ ! -d "${SLOTH_PATH:-}/scripts/package/src/package_managers/" ]] &&
     output::error "The package manager path for core .Sloth could not be found" &&
     exit 1
 
-  package_manager_full_path="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/package/src/package_managers/${package_manager_name}.sh"
+  package_manager_full_path="${SLOTH_PATH:-}/scripts/package/src/package_managers/${package_manager_name}.sh"
 else
   package_manager_full_path="${DOTFILES_PACKAGE_MANAGERS_PATH}/${package_manager_name}.sh"
 fi

--- a/scripts/generator/recipe
+++ b/scripts/generator/recipe
@@ -44,11 +44,11 @@ if ${core:-false}; then
   output::error "WARNING! You will create the package manager in .Sloth core path"
   ! output::yesno "Are you sure you want to continue" && exit 1
 
-  [[ ! -d "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/package/src/recipes/" ]] &&
+  [[ ! -d "${SLOTH_PATH:-}/scripts/package/src/recipes/" ]] &&
     output::error "The package manager path for core .Sloth could not be found" &&
     exit 1
 
-  recipe_full_path="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/package/src/recipes/${recipe_name}.sh"
+  recipe_full_path="${SLOTH_PATH:-}/scripts/package/src/recipes/${recipe_name}.sh"
 else
   recipe_full_path="${DOTFILES_RECIPES_PATH}/${recipe_name}.sh"
 fi

--- a/scripts/generator/script
+++ b/scripts/generator/script
@@ -13,7 +13,7 @@
 ##?   -s --sample        Create a script using more complete example with some comments.
 ##?                      useful if it is your first script. Anyway you can see more help
 ##?                      in the docopt website: http://docopt.org
-##?   -c --core          Create the context and script in "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts" instead of
+##?   -c --core          Create the context and script in "${SLOTH_PATH:-}/scripts" instead of
 ##?                      your "$DOTFILES_PATH/scripts" folder
 ##?   -d --dotly         Generate a Dotly compatible script
 ##?   --author <author>  Provide who is the author, if none the default git author will
@@ -65,7 +65,7 @@ if ${core:-}; then
   output::empty_line
   output::yesno "Are you sure you still want to coninue" "N" || { output::answer "User aborted" && exit 1; }
 
-  script_path="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/$context"
+  script_path="${SLOTH_PATH:-}/scripts/$context"
 else
   if [[ $context == "core" ]] || [[ $context == "package" && $script_name == "add" ]]; then
     output::error "\`$context\` or \`$script_name\` can not be used. Core & package contexts have restrictions when using the generator."

--- a/scripts/generator/src/templates/script-dotly
+++ b/scripts/generator/src/templates/script-dotly
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? XXX_SCRIPT_DESCRIPTION_XXX
 ##?

--- a/scripts/generator/src/templates/script-more-dotly
+++ b/scripts/generator/src/templates/script-more-dotly
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? XXX_SCRIPT_DESCRIPTION_XXX
 ##?

--- a/scripts/mac/defaults
+++ b/scripts/mac/defaults
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 DOTLY_MACOS_SETTINGS_PATH=${DOTLY_MACOS_SETTINGS_PATH:-"${DOTFILES_PATH}/os/mac/settings"}
 
@@ -29,7 +29,7 @@ case $1 in
     current_defaults_path="$(mktemp)"
     defaults read > "$current_defaults_path"
 
-    git diff -w --no-index "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/mac/utils/macos-11.0-defaults" "$current_defaults_path" | delta --side-by-side
+    git diff -w --no-index "${SLOTH_PATH:-}/scripts/mac/utils/macos-11.0-defaults" "$current_defaults_path" | delta --side-by-side
     ;;
   "export")
     if [[ -z "${export_name:-}" ]] || { ${prompt:-false} && ! ${never_prompt:-false}; }; then

--- a/scripts/mac/fix_gem_openssl
+++ b/scripts/mac/fix_gem_openssl
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Fix error with openssl while updating gems
 ##?

--- a/scripts/package/add
+++ b/scripts/package/add
@@ -3,7 +3,7 @@
 
 echo "Received args to add package $*" >> ~/dotly.log
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Install a package
 ##?
@@ -66,9 +66,9 @@ if [[ $number_of_packages -gt 1 ]]; then
   any_error=0
   for pkg in "${packages_names[@]}"; do
     if [[ ${#given_options[@]} -gt 0 ]]; then
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add "${given_options[@]}" "$pkg" || any_error=1
+      "${SLOTH_PATH:-}/bin/dot" package add "${given_options[@]}" "$pkg" || any_error=1
     else
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add "$pkg" || any_error=1
+      "${SLOTH_PATH:-}/bin/dot" package add "$pkg" || any_error=1
     fi
   done
   # Exit here because we want to execute them in order

--- a/scripts/package/brew
+++ b/scripts/package/brew
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 #shellcheck disable=SC2034
 FORCED_PKGMGR="brew"
 

--- a/scripts/package/check
+++ b/scripts/package/check
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 
 ##? Install a package
 ##?

--- a/scripts/package/cleanup
+++ b/scripts/package/cleanup
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Perform a cleanup in all available package managers
 ##?

--- a/scripts/package/dump
+++ b/scripts/package/dump
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "dump.sh"
 
 if platform::command_exists npm; then

--- a/scripts/package/import
+++ b/scripts/package/import
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "dump.sh"
 
 script::depends_on docopts

--- a/scripts/package/install
+++ b/scripts/package/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Install a package
 ##?
@@ -67,9 +67,9 @@ if [[ $number_of_packages -gt 1 ]]; then
   any_error=0
   for pkg in "${packages_names[@]}"; do
     if [[ ${#given_options[@]} -gt 0 ]]; then
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add "${given_options[@]}" "$pkg" || any_error=1
+      "${SLOTH_PATH:-}/bin/dot" package add "${given_options[@]}" "$pkg" || any_error=1
     else
-      "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" package add "$pkg" || any_error=1
+      "${SLOTH_PATH:-}/bin/dot" package add "$pkg" || any_error=1
     fi
   done
   # Exit here because we want to execute them in order

--- a/scripts/package/remove
+++ b/scripts/package/remove
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 uninstall_package_output() {
   [[ -z "${1:-}" ]] && return 1

--- a/scripts/package/update_all
+++ b/scripts/package/update_all
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 update_all_error() {
   [[ -n "${1:-}" ]] && output::write "Error updating ${1:-} apps. See \`dot self debug\` for view errors"
@@ -22,4 +22,4 @@ update_all_error() {
 ##?
 #? v3.1.0
 
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/up" "$@"
+"${SLOTH_PATH:-}/bin/up" "$@"

--- a/scripts/package/which
+++ b/scripts/package/which
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 which_package_output() {
   local package_manager package_name

--- a/scripts/script/install_remote
+++ b/scripts/script/install_remote
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? Install remote context or script in your $DOTFILES_PATH from url. It
 ##? must be the url to the raw file.

--- a/scripts/shell/bash
+++ b/scripts/shell/bash
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? BASH helpers
 ##?

--- a/scripts/shell/zsh
+++ b/scripts/shell/zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 ##? ZSH helpers
 ##?
@@ -37,7 +37,7 @@ case "${1:-}" in
     output::empty_line
 
     output::header "Reloading zsh completions"
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" shell zsh reload_completions
+    "${SLOTH_PATH:-}/bin/dot" shell zsh reload_completions
     output::empty_line
 
     output::header "ASL only storing critical files"

--- a/scripts/symlinks/apply
+++ b/scripts/symlinks/apply
@@ -9,7 +9,7 @@ set -euo pipefail
 ##### End of Hombrew Installation Patch #####
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 dot::load_library "dotbot.sh"
 dot::load_library "symlinks.sh"
 
@@ -156,7 +156,7 @@ yaml_files=()
 tmp_yaml_files=()
 backup_type="ignore"
 backup_suffix="$(date +%s).bak"
-CORE_SYMLINKS_PATH="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/symlinks/src/core"
+CORE_SYMLINKS_PATH="${SLOTH_PATH:-}/scripts/symlinks/src/core"
 USER_SYMLINKS_PATH="${DOTFILES_PATH}/symlinks"
 #shellcheck disable=SC2034
 DOTBOT_BASE_PATH="$DOTFILES_PATH" # is used in dotbot.sh library
@@ -181,9 +181,9 @@ if ${after_core:-false}; then
   ${continue_on_error:-false} && _after_core_args+=(--continue-on-error)
 
   if [[ ${#_after_core_args[@]} -gt 0 ]]; then
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply "${_after_core_args[@]}" core
+    "${SLOTH_PATH:-}/bin/dot" symlinks apply "${_after_core_args[@]}" core
   else
-    "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" symlinks apply core
+    "${SLOTH_PATH:-}/bin/dot" symlinks apply core
   fi
 fi
 

--- a/scripts/symlinks/update
+++ b/scripts/symlinks/update
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 dot::load_library "dotbot.sh"
 
 symlinks::get_files() {
-  [[ -d "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks" ]] &&
-    find "${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks" -name "*.yaml" -type f,l -print0 |
+  [[ -d "${SLOTH_PATH:-}/symlinks" ]] &&
+    find "${SLOTH_PATH:-}/symlinks" -name "*.yaml" -type f,l -print0 |
     xargs -0 -I _ basename _ | sort
 }
 
@@ -38,7 +38,7 @@ docs::parse "$@"
 if [[ -z "$symlinks_file" ]]; then
   symlinks_file="$(symlinks::get_files | symlinks::fzf)"
   [[ -z "$symlinks_file" ]] && exit 0
-  symlinks_file="${SLOTH_PATH:-${DOTLY_PATH:-}}/symlinks/$symlinks_file"
+  symlinks_file="${SLOTH_PATH:-}/symlinks/$symlinks_file"
 else
   for f in "$symlinks_file" "$symlinks_file.yaml" "$symlinks_file.yml"; do
     [[ -e "$f" ]] && symlinks_file="$f" && break

--- a/shell/bash/completions/_dot
+++ b/shell/bash/completions/_dot
@@ -3,8 +3,8 @@
 
 _dot() {
   local script_path suggestions=""
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/dot.sh"
-  . "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/docs.sh"
+  . "${SLOTH_PATH:-}/scripts/core/src/dot.sh"
+  . "${SLOTH_PATH:-}/scripts/core/src/docs.sh"
 
   [[ -n "${BASH_COMP_DEBUG_FILE:-}" ]] && echo "${#COMP_WORDS[@]}" >> "$BASH_COMP_DEBUG_FILE"
   [[ -n "${BASH_COMP_DEBUG_FILE:-}" ]] && echo "${COMP_WORDS[1]}" >> "$BASH_COMP_DEBUG_FILE"
@@ -14,7 +14,7 @@ _dot() {
     2) suggestions=$(compgen -W "$(dot::list_contexts | tr '\n' ' ')") ;;
     3) suggestions="$(dot::list_context_scripts "${COMP_WORDS[1]}" | command -p xargs -I _ command -p basename _)" ;;
     *)
-      script_path="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/${COMP_WORDS[1]}/${COMP_WORDS[2]}"
+      script_path="${SLOTH_PATH:-}/scripts/${COMP_WORDS[1]}/${COMP_WORDS[2]}"
 
       if [[ -r "$script_path" ]]; then
         suggestions="$(docs::parse_docopt_argument "$script_path" "${COMP_WORDS[@]:${#COMP_WORDS[@]}}")"

--- a/shell/init.scripts/autoupdate
+++ b/shell/init.scripts/autoupdate
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-"${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot" core update --async
+"${SLOTH_PATH:-}/bin/dot" core update --async

--- a/shell/zsh/bindings/dot.zsh
+++ b/shell/zsh/bindings/dot.zsh
@@ -1,5 +1,5 @@
 dot-widget() {
-  "${SLOTH_PATH:-${DOTLY_PATH:-}}/bin/dot"
+  "${SLOTH_PATH:-}/bin/dot"
 }
 
 zle -N dot-widget

--- a/shell/zsh/completions/_dot
+++ b/shell/zsh/completions/_dot
@@ -1,6 +1,6 @@
 #compdef dot lazy=dot s=lazy sloth=dot
 
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/src/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/src/_main.sh"
 
 _dot() {
   #setopt local_options xtrace
@@ -12,30 +12,30 @@ _dot() {
     '*: :->args'
 
   case $state in
-  context)
-    existing_contexts=$(dot::list_contexts)
-    _arguments "1:Context:($existing_contexts)"
-    ;;
-  script)
-    existing_scripts=$(dot::list_context_scripts "${words[2]}" | xargs -I _ basename _)
-    _arguments "2:Script:($existing_scripts)"
-    ;;
-  args)
-    script_path="${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/${words[2]}/${words[3]}"
-    if [[ -r "$script_path" ]]; then
-      existing_args="$(docs::parse_docopt_argument "$script_path" "${words[@]:4}")"
-      if [[ -n "$existing_args" ]]; then
-        _arguments "3:Args:($existing_args)"
+    context)
+      existing_contexts=$(dot::list_contexts)
+      _arguments "1:Context:($existing_contexts)"
+      ;;
+    script)
+      existing_scripts=$(dot::list_context_scripts "${words[2]}" | xargs -I _ basename _)
+      _arguments "2:Script:($existing_scripts)"
+      ;;
+    args)
+      script_path="${SLOTH_PATH:-}/scripts/${words[2]}/${words[3]}"
+      if [[ -r "$script_path" ]]; then
+        existing_args="$(docs::parse_docopt_argument "$script_path" "${words[@]:4}")"
+        if [[ -n "$existing_args" ]]; then
+          _arguments "3:Args:($existing_args)"
+        else
+          _files
+        fi
       else
         _files
       fi
-    else
+      ;;
+    *)
       _files
-    fi
-    ;;
-  *)
-    _files
-    ;;
+      ;;
   esac
 }
 

--- a/shell/zsh/completions/_dot
+++ b/shell/zsh/completions/_dot
@@ -12,30 +12,30 @@ _dot() {
     '*: :->args'
 
   case $state in
-    context)
-      existing_contexts=$(dot::list_contexts)
-      _arguments "1:Context:($existing_contexts)"
-      ;;
-    script)
-      existing_scripts=$(dot::list_context_scripts "${words[2]}" | xargs -I _ basename _)
-      _arguments "2:Script:($existing_scripts)"
-      ;;
-    args)
-      script_path="${SLOTH_PATH:-}/scripts/${words[2]}/${words[3]}"
-      if [[ -r "$script_path" ]]; then
-        existing_args="$(docs::parse_docopt_argument "$script_path" "${words[@]:4}")"
-        if [[ -n "$existing_args" ]]; then
-          _arguments "3:Args:($existing_args)"
-        else
-          _files
-        fi
+  context)
+    existing_contexts=$(dot::list_contexts)
+    _arguments "1:Context:($existing_contexts)"
+    ;;
+  script)
+    existing_scripts=$(dot::list_context_scripts "${words[2]}" | xargs -I _ basename _)
+    _arguments "2:Script:($existing_scripts)"
+    ;;
+  args)
+    script_path="${SLOTH_PATH:-}/scripts/${words[2]}/${words[3]}"
+    if [[ -r "$script_path" ]]; then
+      existing_args="$(docs::parse_docopt_argument "$script_path" "${words[@]:4}")"
+      if [[ -n "$existing_args" ]]; then
+        _arguments "3:Args:($existing_args)"
       else
         _files
       fi
-      ;;
-    *)
+    else
       _files
-      ;;
+    fi
+    ;;
+  *)
+    _files
+    ;;
   esac
 }
 

--- a/shell/zsh/themes/prompt_codely_setup
+++ b/shell/zsh/themes/prompt_codely_setup
@@ -34,7 +34,7 @@ fi
 
 prompt_codely_pwd() {
   case "$CODELY_THEME_PWD_MODE" in
-    short) local -r prompt_dir=$("${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/short_pwd") ;;
+    short) local -r prompt_dir=$("${SLOTH_PATH:-}/scripts/core/short_pwd") ;;
     full) local -r prompt_dir="$PWD" ;;
     home_relative) local -r prompt_dir=$(print -rD "$PWD") ;;
   esac

--- a/shell/zsh/themes/prompt_codelytv_setup
+++ b/shell/zsh/themes/prompt_codelytv_setup
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/shell/zsh/themes/prompt_codely_setup"
+. "${SLOTH_PATH:-}/shell/zsh/themes/prompt_codely_setup"
 
 prompt_codelytv_setup() {
   prompt_codely_setup "$@"


### PR DESCRIPTION
## What

Completes the DOTLY_PATH fallback refactor started in #255. Replaces 121 occurrences of `/Users/gtrabanco/MyProjects/dotSloth}` with the canonical `/Users/gtrabanco/MyProjects/dotSloth` in 48 files across `scripts/`, `bin/`, `restorer`, `installer`, `shell/`, `dotfiles_template/`.

## Why

The fallback is redundant because `_main.sh` (line 10) and `init-sloth.sh` (line 77) already resolve `SLOTH_PATH` from `DOTLY_PATH` before any downstream code runs. The dual-variable pattern was a transitional compatibility shim from the #255 refactor.

## Preserved exceptions

Fallback kept in resolution blocks and initial checks that run **before** `_main.sh` is sourced:
- `bin/dot:12,13` — initial check before resolution
- `bin/sloth:10,13` — initial check + `_main.sh` sourcing
- `restorer:325` — `export SLOTH_PATH` resolution block
- `installer:314` — `export SLOTH_PATH` resolution block
- `scripts/init/{enable,disable,status}:5,8` — initial check + `_main.sh`
- `scripts/core/install:12` — `BASH_SOURCE` resolution block
- `scripts/core/src/_main.sh:10` — early resolution block
- `shell/init-sloth.sh:77` — compat layer

## Evidence

- Gate: static_analysis ✅, lint ✅, 48/48 tests ✅
- `grep -rn 'SLOTH_PATH:-${DOTLY_PATH' scripts/ bin/ restorer installer shell/ dotfiles_template/` → only preserved lines remain
- `docs/architecture/ARCHITECTURE.md:32` updated to canonical pattern

Closes #266