### PR TITLE
fix(dot): split fzf selection into ctx+scr args for correct dispatch

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -106,7 +106,7 @@ elif [[ "${1:-}" == "shellenv" ]] && args::total_is 1 "$@"; then
 fi
 
 fzf_prompt() {
-  local fzf_scripts fzf_context fzf_script full_script script
+  local fzf_scripts fzf_context fzf_script full_script script ctx scr args
   ! command -v fzf > /dev/null 2>&1 && return 1
 
   for full_script in $(printf "%s\n" "$@"); do
@@ -118,10 +118,21 @@ fzf_prompt() {
 
   script="$(printf "%s\n" "${fzf_scripts[@]}" | files::fzf --sloth-core --preview 'dot::fzf_view_doc {}' --height 100%)"
 
-  printf "%s" "$script"
+  # script is "context script" (space-separated); split into two args for dispatch
+  read -r ctx scr <<< "$script"
+  [[ -n "${scr:-}" ]] || {
+    output::error "No script selected."
+    exit 1
+  }
+
+  printf "%s %s" "$ctx" "$scr"
   read -r args
 
-  "${SLOTH_PATH:-}/bin/dot" "${script}" "${args}"
+  if [[ -n "$args" ]]; then
+    "${SLOTH_PATH:-}/bin/dot" "$ctx" "$scr" "$args"
+  else
+    "${SLOTH_PATH:-}/bin/dot" "$ctx" "$scr"
+  fi
 }
 
 script_exist() {


### PR DESCRIPTION
## What

Fixes `fzf_prompt` in `bin/dot` — when selecting a script via fzf (e.g. `dot core` → select `core update`), the selected entry was passed as a single quoted argument, causing the dispatcher to look for `scripts/core update/` instead of `scripts/core/update`.

## Root cause

`fzf_prompt` built entries as `" "` (e.g. `"core update"`) and dispatched with:

```bash
"${SLOTH_PATH:-}/bin/dot" "${script}" "${args}"
```

Because `"${script}"` is quoted, `"core update"` is passed as a **single argument**. The dispatcher receives `context="core update"` and `script=""` → not found.

## Fix

Split `` into `ctx` and `scr` via `read -r ctx scr <<< "$script"`, then dispatch as two separate arguments. Also guard against empty selection and avoid passing an empty `args` string.

## Evidence

- Gate: static_analysis ✅, lint ✅, 60/60 tests ✅
- Reproduced before fix: `bin/dot "core update" "" → "The script <core update / > doesn't exist"`
- After fix: `read -r ctx scr <<< "core update" → ctx=core scr=update → bin/dot core update` works

Closes #276