### PR TITLE
fix(git): pass args to git diff-index in git::is_clean

### DIFF
--- a/scripts/core/src/git.sh
+++ b/scripts/core/src/git.sh
@@ -170,10 +170,10 @@ git::check_unpushed_commits() {
 #"
 git::is_clean() {
   # Changes that are indexed: git add
-  # "${GIT_EXECUTABLE}" diff-index --no-ext-diff --quiet --exit-code --cached --ignore-submodules="all" HEAD -- || return 1
+  # "${GIT_EXECUTABLE}" "$@" diff-index --no-ext-diff --quiet --exit-code --cached --ignore-submodules="all" HEAD -- || return 1
 
   # Changed tracked files that are not indexed: previous to git add
-  "${GIT_EXECUTABLE}" diff-index --no-ext-diff --quiet --exit-code --ignore-submodules="all" HEAD -- || return 1
+  "${GIT_EXECUTABLE}" "$@" diff-index --no-ext-diff --quiet --exit-code --ignore-submodules="all" HEAD -- || return 1
 }
 
 #;


### PR DESCRIPTION
## What

Fixes `git::is_clean()` in `scripts/core/src/git.sh` — the function ignored its arguments, executing `git diff-index` in the current working directory instead of the path specified by `-C`.

## Root cause

`git::is_clean()` receives `SLOTH_UPDATE_GIT_ARGS` (containing `-C "$SLOTH_PATH"`) from `sloth_update::local_sloth_repository_can_be_updated()`, but did not pass `"$@"` to the git command:

```bash
# Before (broken)
"${GIT_EXECUTABLE}" diff-index ... HEAD -- || return 1

# After (fixed)
"${GIT_EXECUTABLE}" "$@" diff-index ... HEAD -- || return 1
```

All other `git::` functions (`git::git`, `git::check_remote_exists`, `git::check_branch_is_ahead`) already pass `"$@"` — only `git::is_clean` was missing it.

## Symptom

Running `dot core update` from any directory other than `/Users/gtrabanco/MyProjects/dotSloth` (e.g. from `~`) failed:

```
fatal: not a git repository (or any of the parent directories): .git
 > Can't be updated
 > Something went wrong
```

## Evidence

- Gate: static_analysis ✅, lint ✅, 60/60 tests ✅
- Reproduced before fix: `git diff-index` in `~` → fatal error
- After fix: `git -C "$SLOTH_PATH" diff-index` → works correctly

Closes #278