### PR TITLE
fix(path): replace DOTLY_PATH fallback in init scripts

### DIFF
--- a/docs/fix/280-remaining-path-fallback/REVIEW.md
+++ b/docs/fix/280-remaining-path-fallback/REVIEW.md
@@ -1,0 +1,51 @@
+# Review — fix/280-remaining-path-fallback
+
+**Date:** 2026-07-05
+**Branch:** fix/280-remaining-path-fallback
+**Commits:** b501a8b (SPEC), 372f439 (implementation)
+**Size:** XS
+
+## Diff summary
+
+6 mechanical replacements of `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}`
+in `scripts/init/{enable,disable,status}` (lines 5 and 8 of each).
+
+## Findings
+
+### Correctness — PASS
+
+- The replacements are correct. `bin/dot` exports `SLOTH_PATH` before
+  dispatching context scripts (bin/dot:190), making the `DOTLY_PATH` fallback
+  redundant in these files.
+- The guard check on line 5 still functions: if `SLOTH_PATH` is empty, the
+  script exits with code 1.
+- Line 8 sources `_main.sh` using `${SLOTH_PATH:-}` — if `SLOTH_PATH` is set
+  (guaranteed by `bin/dot` dispatch), the path resolves correctly.
+
+### Scope — PASS
+
+- Only the 3 in-scope files were modified.
+- Out-of-scope files verified untouched: `_main.sh`, `init-sloth.sh`,
+  `bin/dot`, `bin/sloth`, `restorer`, `installer`, `scripts/core/install`.
+
+### Gate — PASS
+
+- `bash scripts/self/static_analysis` — exit 0
+- `bash scripts/self/lint` — exit 0
+- `make test` — 60 ok, 0 not ok
+
+### Security — n/a
+
+No auth, secrets, or PII involved.
+
+### Performance — n/a
+
+Mechanical variable reference change, no performance impact.
+
+### Fix-now findings
+
+None.
+
+## Verdict
+
+MERGE-READY — no blockers, no fix-now findings.

--- a/docs/fix/280-remaining-path-fallback/SPEC.md
+++ b/docs/fix/280-remaining-path-fallback/SPEC.md
@@ -1,0 +1,140 @@
+# fix/280-remaining-path-fallback
+
+> Fix specification. Copy this folder to `docs/fix/<issue-number>-<topic>/`, fill
+> every section, and register the entry in `docs/fix/README.md`. Lighter than a
+> feature spec — no planning artifacts. The SPEC alone is the source of truth.
+
+## Goal
+
+Replace 6 remaining redundant `${SLOTH_PATH:-${DOTLY_PATH:-}}` fallback patterns
+in `scripts/init/{enable,disable,status}` with `${SLOTH_PATH:-}`. These scripts
+are dispatched via `bin/dot` which sets `SLOTH_PATH` in the environment before
+invocation (line 190), making the `DOTLY_PATH` fallback redundant.
+
+## Issue
+
+`#280` — tracked issue. Required. The PR must close it.
+
+## Branch
+
+`fix/280-remaining-path-fallback`
+
+## Root cause
+
+Issue #255 and #266 refactored most `DOTLY_PATH` fallback patterns but left 15
+occurrences. Of those, 6 are in context scripts (`scripts/init/`) that are
+dispatched via `bin/dot` which already exports `SLOTH_PATH` at line 190:
+
+```bash
+SLOTH_PATH="$SLOTH_PATH" DOTLY_PATH="${SLOTH_PATH:-}" DOTFILES_PATH="${DOTFILES_PATH:-}" "$script_full_path" "$@"
+```
+
+The remaining 9 occurrences are structurally necessary:
+- `scripts/core/src/_main.sh:10` — compatibility layer (must NOT change)
+- `bin/dot:12,13` — pre-resolution entry point (must NOT change)
+- `bin/sloth:10,13` — pre-resolution entry point (must NOT change)
+- `restorer:325` — standalone bootstrap (must NOT change)
+- `installer:314` — standalone bootstrap (must NOT change)
+- `shell/init-sloth.sh:77` — compatibility layer (must NOT change)
+
+## Scope
+
+### In scope
+
+Replace 6 occurrences across 3 files:
+
+| File | Lines | Change |
+|------|-------|--------|
+| `scripts/init/enable` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |
+| `scripts/init/disable` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |
+| `scripts/init/status` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |
+
+### Out of scope
+
+- `scripts/core/src/_main.sh:10` — compatibility layer, intentionally preserved
+- `bin/dot:12,13` — entry point pre-resolution fallback, structurally necessary
+- `bin/sloth:10,13` — entry point pre-resolution fallback, structurally necessary
+- `restorer:325` — standalone bootstrap, runs before `_main.sh` is available
+- `installer:314` — standalone bootstrap, runs before `_main.sh` is available
+- `shell/init-sloth.sh:77` — compatibility layer, intentionally preserved
+- Adding `set -euo pipefail` to scripts that lack it — tracked in #269
+
+## Impact
+
+- Modules/files touched: 3 files (`scripts/init/enable`, `scripts/init/disable`,
+  `scripts/init/status`), 2 lines each.
+- Blast radius: low — these are context scripts dispatched via `bin/dot` which
+  already resolves `SLOTH_PATH` before invocation.
+- Detection lead time: immediate — if `SLOTH_PATH` is not set, the guard check
+  on line 5 exits with code 1, which `bin/dot` propagates.
+
+## Rules that must never be violated
+
+- `shell/init-sloth.sh:76-78` must NOT be modified (compatibility layer).
+- `scripts/core/src/_main.sh:8-10` must NOT be modified (early resolution block).
+- `bin/dot` and `bin/sloth` entry points: preserve fallback in initial check
+  (before resolution block).
+- `restorer` and `installer`: preserve fallback before their resolution blocks.
+- `shfmt -ln bash -sr -ci -i 2 -d` must pass on all modified files.
+- `shellcheck` must pass.
+- Context scripts must source `_main.sh` first (ARCHITECTURE.md:29-33).
+
+## Risks
+
+- **Operational**: n/a — the scripts are only invoked via `bin/dot` which sets
+  `SLOTH_PATH` in the environment. The guard check on line 5 provides a safety
+  net: if `SLOTH_PATH` is unset, the script exits immediately.
+- **Security**: n/a — no auth, secrets, PII.
+- **Compliance**: n/a.
+- **Backward compatibility**: n/a — `DOTLY_PATH` is still set as an alias by
+  `init-sloth.sh` for users who reference it in their shell config.
+
+## Acceptance criteria
+
+- [ ] 0 occurrences of `${SLOTH_PATH:-${DOTLY_PATH:-}}` remain in
+      `scripts/init/{enable,disable,status}`
+- [ ] `scripts/core/src/_main.sh:10` unchanged
+- [ ] `shell/init-sloth.sh:77` unchanged
+- [ ] `bin/dot:12,13` unchanged
+- [ ] `bin/sloth:10,13` unchanged
+- [ ] `restorer:325` unchanged
+- [ ] `installer:314` unchanged
+- [ ] `bash scripts/self/static_analysis` passes clean
+- [ ] `bash scripts/core/lint` passes clean
+- [ ] `make test` passes (48+ existing tests)
+
+## Rollback
+
+Revert the PR. No data-side cleanup needed — the refactor only changes variable
+reference patterns, no state is modified.
+
+## Effort
+
+**XS** — 3 files, 6 lines, mechanical replacement. ≤ 1h including verification.
+
+## Observability
+
+- Before: `scripts/init/{enable,disable,status}` use `${SLOTH_PATH:-${DOTLY_PATH:-}}`.
+- After: `scripts/init/{enable,disable,status}` use `${SLOTH_PATH:-}`.
+- Failure mode: if `SLOTH_PATH` is not resolved, the guard check on line 5
+  exits immediately — detectable on first invocation.
+
+## Cross-issue notes
+
+- #255 — prerequisite, already merged. This fix continues the refactor.
+- #266 — prerequisite, already merged. This fix continues the refactor.
+- #269 (set -euo pipefail migration) — parallel, no overlap. These scripts
+  already have `set -euo pipefail`.
+- #274 (dotly.bats test failure) — unrelated, different issue.
+- #275 (CI bats tests) — unrelated, different issue.
+
+## Decisions made during drafting
+
+- `scripts/core/install:12` — left out of scope. It has additional logic with
+  `BASH_SOURCE` that derives `SLOTH_PATH` from the script's own path. The
+  fallback pattern there is structurally different and should be evaluated
+  separately if needed.
+- Only context scripts dispatched via `bin/dot` are targeted. Standalone scripts
+  (`restorer`, `installer`) and entry points (`bin/dot`, `bin/sloth`) retain
+  their fallback patterns because they resolve `SLOTH_PATH` before `_main.sh`
+  is available.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
 | 265-gem-update-false-positive | gem::update_apps silently fails on broken system Ruby | done · [#270](https://github.com/gtrabanco/dotSloth/pull/270) | — | [#265](https://github.com/gtrabanco/dotSloth/issues/265) |
-| 280-remaining-path-fallback | Remaining DOTLY_PATH fallback in init scripts | pending | — | [#280](https://github.com/gtrabanco/dotSloth/issues/280) |
+| 280-remaining-path-fallback | Remaining DOTLY_PATH fallback in init scripts | done · [#281](https://github.com/gtrabanco/dotSloth/pull/281) | — | [#280](https://github.com/gtrabanco/dotSloth/issues/280) |
 | 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | pending | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,6 +15,7 @@ history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
 | 265-gem-update-false-positive | gem::update_apps silently fails on broken system Ruby | done · [#270](https://github.com/gtrabanco/dotSloth/pull/270) | — | [#265](https://github.com/gtrabanco/dotSloth/issues/265) |
+| 280-remaining-path-fallback | Remaining DOTLY_PATH fallback in init scripts | pending | — | [#280](https://github.com/gtrabanco/dotSloth/issues/280) |
 | 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | pending | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
 

--- a/scripts/init/disable
+++ b/scripts/init/disable
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 dot::load_library "init.sh"
 
 ##? Disable init scripts

--- a/scripts/init/enable
+++ b/scripts/init/enable
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 dot::load_library "init.sh"
 
 ##? Enable init scripts

--- a/scripts/init/status
+++ b/scripts/init/status
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-[[ -z "${SLOTH_PATH:-${DOTLY_PATH:-}}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
+[[ -z "${SLOTH_PATH:-}" || -z "${DOTFILES_PATH:-}" ]] && exit 1
 
 #shellcheck disable=SC1091
-. "${SLOTH_PATH:-${DOTLY_PATH:-}}/scripts/core/_main.sh"
+. "${SLOTH_PATH:-}/scripts/core/_main.sh"
 dot::load_library "init.sh"
 
 ##? Check iinit-script status


### PR DESCRIPTION
## Summary

Replace 6 remaining `${SLOTH_PATH:-${DOTLY_PATH:-}}` fallback patterns with `${SLOTH_PATH:-}` in `scripts/init/{enable,disable,status}`.

These context scripts are dispatched via `bin/dot` which exports `SLOTH_PATH` before invocation (line 190), making the `DOTLY_PATH` fallback redundant.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `scripts/init/enable` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |
| `scripts/init/disable` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |
| `scripts/init/status` | 5, 8 | `${SLOTH_PATH:-${DOTLY_PATH:-}}` → `${SLOTH_PATH:-}` |

## Out of scope (structurally necessary, preserved)

- `scripts/core/src/_main.sh:10` — compatibility layer
- `shell/init-sloth.sh:77` — compatibility layer
- `bin/dot:12,13` — entry point pre-resolution fallback
- `bin/sloth:10,13` — entry point pre-resolution fallback
- `restorer:325` — standalone bootstrap
- `installer:314` — standalone bootstrap

## Verification

- `bash scripts/self/static_analysis` — PASS (exit 0)
- `bash scripts/self/lint` — PASS (exit 0)
- `make test` — PASS (60 ok, 0 not ok)

Closes #280
