### PR TITLE
fix(scripts): add set -euo pipefail to standalone entry-point scripts

### DIFF
--- a/bin/$
+++ b/bin/$
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Useful when you c&p commands from the internet :P
 

--- a/bin/open
+++ b/bin/open
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Open command if open exists in system
 SCRIPT_PATH="$(cd -- "$(dirname "$0")" && pwd -P)"

--- a/bin/pbcopy
+++ b/bin/pbcopy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if command -v xclip > /dev/null 2>&1; then
   xclip -selection clipboard

--- a/bin/pbpaste
+++ b/bin/pbpaste
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if command -v xclip > /dev/null 2>&1; then
   xclip -selection clipboard -o

--- a/docs/fix/269-set-euo-pipefail/SPEC.md
+++ b/docs/fix/269-set-euo-pipefail/SPEC.md
@@ -1,0 +1,62 @@
+# Fix: Migrate remaining scripts to set -euo pipefail
+
+## Issue
+
+[#269](https://github.com/gtrabanco/dotSloth/issues/269) — Migrate remaining scripts to set -euo pipefail
+
+## Problem
+
+The architecture doc mandates `set -euo pipefail` for all bash scripts, and CI
+enforces it via shellcheck. Several entry-point scripts lack it. Scripts that
+source `_main.sh` (via the sloth shebang or direct `source`) already inherit
+`set -euo pipefail` from `_main.sh`, but standalone entry points need it
+explicitly.
+
+## Scope
+
+Add `set -euo pipefail` after the shebang in 7 standalone entry-point scripts,
+and fix 1 script that has `set -uo pipefail` (missing `-e`).
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `bin/$` | Add `set -euo pipefail` after shebang |
+| `bin/open` | Add `set -euo pipefail` after shebang |
+| `bin/pbcopy` | Add `set -euo pipefail` after shebang |
+| `bin/pbpaste` | Add `set -euo pipefail` after shebang |
+| `scripts/core/short_pwd` | Add `set -euo pipefail` after shebang |
+| `scripts/core/migration` | Change `set -uo pipefail` → `set -euo pipefail` |
+| `scripts/generator/recipe` | Add `set -euo pipefail` after shebang |
+| `scripts/generator/script` | Add `set -euo pipefail` after shebang |
+
+### Files NOT modified (intentionally)
+
+- `scripts/core/src/*.sh` — sourced by `_main.sh`, inherits from it
+- `scripts/package/src/package_managers/*.sh` — sourced via `dot::load_library`
+- `scripts/package/src/recipes/*.sh` — sourced via `dot::load_library`
+- `scripts/symlinks/src/*.sh` — sourced by symlinks entry points
+- `scripts/init/src/init.sh` — sourced by init entry points
+- `scripts/generator/src/templates/*` — templates, not executed
+- Scripts that source `_main.sh` directly (already inherit `set -euo pipefail`)
+
+## Acceptance criteria
+
+1. All 8 target files have `set -euo pipefail` after their shebang line
+2. `bash scripts/core/lint` passes
+3. `bash scripts/self/static_analysis` passes
+4. `make test` passes
+5. No behavioral change — adding `set -e` to scripts that previously lacked it
+   may surface latent errors; if any surface, they must be fixed in this fix
+
+## Risk
+
+Low — mechanical addition. Scripts that source `_main.sh` already run under
+`set -euo pipefail`, so this makes the explicit declaration match the runtime
+reality. The only risk is if a script has a command that fails non-fatally
+under `set -e` where it previously didn't; such cases will be caught by the
+test gate.
+
+## Branch
+
+`fix/269-set-euo-pipefail`

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -18,6 +18,7 @@ history lives in git log + closed issues.
 | 280-remaining-path-fallback | Remaining DOTLY_PATH fallback in init scripts | done · [#281](https://github.com/gtrabanco/dotSloth/pull/281) | — | [#280](https://github.com/gtrabanco/dotSloth/issues/280) |
 | 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | pending | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
+| 269-set-euo-pipefail | Migrate remaining scripts to set -euo pipefail | done · pending PR | — | [#269](https://github.com/gtrabanco/dotSloth/issues/269) |
 
 ## Conventions
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -18,7 +18,7 @@ history lives in git log + closed issues.
 | 280-remaining-path-fallback | Remaining DOTLY_PATH fallback in init scripts | done · [#281](https://github.com/gtrabanco/dotSloth/pull/281) | — | [#280](https://github.com/gtrabanco/dotSloth/issues/280) |
 | 266-complete-path-fallback-refactor | Complete DOTLY_PATH fallback refactor in context scripts | pending | — | [#266](https://github.com/gtrabanco/dotSloth/issues/266) |
 | 240-testing-framework-finalize | Add 10th test file to meet acceptance criterion #5 | pending | — | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
-| 269-set-euo-pipefail | Migrate remaining scripts to set -euo pipefail | done · pending PR | — | [#269](https://github.com/gtrabanco/dotSloth/issues/269) |
+| 269-set-euo-pipefail | Migrate remaining scripts to set -euo pipefail | done · [#282](https://github.com/gtrabanco/dotSloth/pull/282) | — | [#269](https://github.com/gtrabanco/dotSloth/issues/269) |
 
 ## Conventions
 

--- a/scripts/core/migration
+++ b/scripts/core/migration
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 
 [[ -z "${SLOTH_PATH:-}" ]] && exit 1
 

--- a/scripts/generator/recipe
+++ b/scripts/generator/recipe
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 ##? Generate a recipe for a package
 ##?
 ##?

--- a/scripts/generator/script
+++ b/scripts/generator/script
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 ##? Generate a .Sloth script
 ##?
 ##?


### PR DESCRIPTION
## What

Add `set -euo pipefail` after the shebang in 7 standalone bash entry-point scripts that lacked it, and fix `scripts/core/migration` which had `set -uo pipefail` (missing `-e`).

## Why

The architecture doc mandates `set -euo pipefail` for all bash scripts, and CI enforces it via shellcheck. Scripts that source `_main.sh` (via the sloth shebang or direct source) already inherit `set -euo pipefail` from `_main.sh`, but standalone entry points need it explicitly.

## Files modified

- `bin/$` — added `set -euo pipefail`
- `bin/open` — added `set -euo pipefail`
- `bin/pbcopy` — added `set -euo pipefail`
- `bin/pbpaste` — added `set -euo pipefail`
- `scripts/core/migration` — changed `set -uo pipefail` → `set -euo pipefail`
- `scripts/generator/recipe` — added `set -euo pipefail`
- `scripts/generator/script` — added `set -euo pipefail`

## Evidence

```
$ bash scripts/self/static_analysis   # ✓ clean
$ bash scripts/core/lint              # ✓ clean
$ make test                           # ✓ 60 ok
$ shellcheck -s bash bin/$ bin/open bin/pbcopy bin/pbpaste scripts/core/migration scripts/generator/recipe scripts/generator/script  # ✓ clean
```

## Not modified (intentionally)

Scripts that source `_main.sh` already inherit `set -euo pipefail`: `bin/dot`, `bin/sloth`, `bin/up`, `scripts/core/version`, `scripts/mac/defaults`, `scripts/package/*`, `scripts/shell/zsh`, `scripts/generator/bin`, `scripts/generator/package_manager`.

`scripts/core/short_pwd` uses zsh (`#!/usr/bin/env zsh`), not bash — `set -euo pipefail` is not directly applicable.

Closes #269
