### PR TITLE
fix(update): repair broken dot core update

### DIFF
--- a/scripts/core/src/git.sh
+++ b/scripts/core/src/git.sh
@@ -267,7 +267,7 @@ git::remote_latest_tag_version() {
   local -r version_pattern="${2:-v*.*.*}"
   [[ -z "$remote_url" ]] && return
 
-  git::git "${@:3}" ls-remote --tags --refs "$remote_url" "${version_pattern}" 2> /dev/null | command awk '{gsub(/\\^\\{\\}/,"", $NF);gsub("refs/tags/",""); gsub("v",""); print $NF}' | command sort -Vur | command head -n1
+  git::git "${@:3}" ls-remote --tags --refs "$remote_url" "${version_pattern}" 2> /dev/null | command awk '{gsub(/\^\{\}/,"", $NF);gsub("refs/tags/",""); gsub("v",""); print $NF}' | command sort -Vur | command head -n1
 }
 
 #;

--- a/scripts/core/src/sloth_update.sh
+++ b/scripts/core/src/sloth_update.sh
@@ -71,7 +71,9 @@ sloth_update::sloth_repository_set_ready() {
   git::clone_track_branch "${SLOTH_DEFAULT_REMOTE:-origin}" "${SLOTH_DEFAULT_BRANCH:-main}" "${SLOTH_UPDATE_GIT_ARGS[@]}" 1>&2 || true
 
   # Unshallow by the way
-  git::git "${SLOTH_UPDATE_GIT_ARGS[@]}" fetch --unshallow 1>&2 || true
+  if git::git "${SLOTH_UPDATE_GIT_ARGS[@]}" rev-parse --is-shallow-repository 2> /dev/null | grep -q true; then
+    git::git "${SLOTH_UPDATE_GIT_ARGS[@]}" fetch --unshallow 1>&2 || true
+  fi
 }
 
 #;


### PR DESCRIPTION
## Summary

`dot core update` is broken — two bugs prevent the update from completing.

## What changed

### Bug 1: `git fetch --unshallow` on complete repository
`scripts/core/src/sloth_update.sh:74` ran `git fetch --unshallow` unconditionally. On non-shallow clones (the common case), this fails with:
```
fatal: --unshallow on a complete repository does not make sense
```

**Fix:** Only run `--unshallow` when the repo is actually shallow, checked via `git rev-parse --is-shallow-repository`.

### Bug 2: Invalid awk regex on BSD awk (macOS)
`scripts/core/src/git.sh:270` used the regex `/\\^\\{\\}/` which is invalid on BSD awk (macOS default), causing:
```
awk: syntax error in regular expression \\^\\{\\} at \\{\\}
```

The extra backslashes made the regex match a literal `\^{}` instead of `^{}`. Fixed to `/\^\{\}/` which correctly strips the `^{}` suffix from `git ls-remote --tags` output.

## Evidence

- `bash scripts/self/static_analysis` — ✓
- `bash scripts/self/lint` — ✓
- `make test` — ✓ (60 tests)
- Manual test: `sloth_update::sloth_repository_set_ready` no longer prints `fatal: --unshallow`
- Manual test: `sloth_update::get_latest_stable_version` returns `4.3.1` (no awk error)
