### PR TITLE
fix(update): show 'already latest' instead of error when up-to-date

### DIFF
--- a/scripts/core/src/sloth_update.sh
+++ b/scripts/core/src/sloth_update.sh
@@ -271,11 +271,13 @@ sloth_update::sloth_update() {
   # Remote exists?
   ! git::check_remote_exists "$remote" "${SLOTH_UPDATE_GIT_ARGS[@]}" 1>&2 && output::error "Remote \`${remote}\` does not exists" && return 20
 
-  # Get remote HEAD branch
+  # Get remote HEAD branch (strip remote prefix to get bare branch name)
   head_branch="$(git::get_remote_head_upstream_branch "$remote" "${SLOTH_UPDATE_GIT_ARGS[@]}")"
+  head_branch="${head_branch#${remote}/}"
   if [[ -z "$head_branch" ]]; then
     git::set_remote_head_upstream_branch "$remote" "$default_remote_branch" "${SLOTH_UPDATE_GIT_ARGS[@]}"
     head_branch="$(git::get_remote_head_upstream_branch "$remote" "${SLOTH_UPDATE_GIT_ARGS[@]}")"
+    head_branch="${head_branch#${remote}/}"
 
     [[ -z "$head_branch" ]] && output::error "Remote \`${remote}\` does not have a default branch and \`${default_branch}\` could not be set" && return 30
   fi
@@ -309,7 +311,8 @@ sloth_update::gracefully() {
   sloth_update::sloth_repository_set_ready || true
 
   if ! sloth_update::should_be_updated; then
-    # Already up to date
+    # Already up to date — clean stale availability marker
+    rm -f "${SLOTH_UPDATE_AVAILABE_FILE:-"${DOTFILES_PATH:-${HOME}}/.sloth_update_available"}"
     return
   fi
 

--- a/scripts/core/update
+++ b/scripts/core/update
@@ -66,7 +66,7 @@ if [[ $status -ne 0 ]]; then
       exit $status
       ;;
     40)
-      output::error "No updated something was wrong"
+      output::error "Update failed — git pull could not complete. Check log using \`dot core debug\`"
       exit $status
       ;;
     1)


### PR DESCRIPTION
## Summary

`dot self-update` shows "No updated something was wrong" when the user is already on the latest version. This is a UX bug — "already up to date" should be a success, not a failure.

## What changed

### Bug 1: `head_branch` includes `origin/` prefix (root cause)
`scripts/core/src/sloth_update.sh:275` — `git::get_remote_head_upstream_branch` returns `origin/main` (with the remote prefix), but `git::pull_branch` expects the bare branch name `main`. This caused `git::remote_branch_exists` to look for `origin/origin/main` (double prefix), fail, and return 40.

**Fix:** Strip the `${remote}/` prefix from `head_branch` before passing it to `git::pull_branch`.

### Bug 2: Stale `.sloth_update_available` file (feedback loop)
`scripts/core/src/sloth_update.sh:313` — when `should_be_updated` returns false (already up to date), the stale `.sloth_update_available` marker file was never cleaned up. On the next run, `should_be_updated` sees the file and returns true unconditionally, causing `sloth_update::sloth_update` to be called and fail with 40 — which leaves the file again. A feedback loop.

**Fix:** Remove the stale `.sloth_update_available` file when `should_be_updated` returns false.

### Bug 3: Unhelpful error message
`scripts/core/update:69` — "No updated something was wrong" doesn't tell the user what to do.

**Fix:** Replaced with "Update failed — git pull could not complete. Check log using `dot core debug`".

## Evidence

- `bash scripts/self/static_analysis` — ✓
- `bash scripts/self/lint` — ✓
- `make test` — ✓ (60 tests)
- Root cause confirmed via `set -x` trace: `git::remote_branch_exists` was called with `origin/origin/main` (double prefix)
