### PR TITLE
fix(install_remote): replace eval with array-based invocation

### DIFF
--- a/docs/fix/288-eval-injection/SPEC.md
+++ b/docs/fix/288-eval-injection/SPEC.md
@@ -1,0 +1,46 @@
+# fix/288-eval-injection
+
+> Fix specification. Lighter than a feature spec — no planning artifacts. The SPEC alone is the source of truth.
+
+## Goal
+
+Replace `eval "$download_command $script_raw_url"` in `scripts/script/install_remote:51` with a proper array-based invocation to eliminate the command injection vector via the user-provided `script_raw_url` argument.
+
+## Issue
+
+`#288` — tracked issue. Required. The PR must close it.
+
+## Branch
+
+`fix/288-eval-injection`
+
+## Root cause
+
+`install_remote` builds a curl command as a string (`download_command="$CURL_BIN -k -L -f -q $script_name_args"`) then executes it with `eval "$download_command $script_raw_url"`. The `script_raw_url` is a user-provided argument (`dot script install_remote <context> <url>`). A URL containing shell metacharacters (`; rm -rf ~`, `$(cmd)`, `` `cmd` ``) would be executed by `eval`.
+
+Secondary issue: `if [ ! $? ]` on line 52 is always false — `$?` is consumed by the `[` command itself, so it always checks `[ ! 0 ]` which is false.
+
+## Fix
+
+1. Replace string-based command building with a bash array.
+2. Replace `eval` with direct array expansion: `"${curl_args[@]}" "$script_raw_url"`.
+3. Capture the exit code immediately: `curl_exit=$?` instead of `if [ ! $? ]`.
+4. Keep `-k` flag (intentional for downloading from various sources — noted as a separate concern, not fixed here).
+
+## Scope
+
+- `scripts/script/install_remote` — lines 36-57
+- No other files affected
+
+## Acceptance criteria
+
+- [ ] No `eval` in `scripts/script/install_remote`
+- [ ] `script_raw_url` is passed as a single quoted argument to curl (no shell expansion)
+- [ ] Exit code is captured immediately after the curl command
+- [ ] `bash scripts/core/static_analysis` passes
+- [ ] `bash scripts/core/lint` passes
+- [ ] `make test` passes
+
+## Testing requirements
+
+Manual verification: `dot script install_remote test_context "https://example.com/raw/script.sh"` downloads the file without executing the URL as a command.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| (none — all fixes merged) | | | | |
+| 288-eval-injection | eval with user-provided URL is a command injection vector | in-progress | — | [#288](https://github.com/gtrabanco/dotSloth/issues/288) |
 
 ## Conventions
 

--- a/scripts/script/install_remote
+++ b/scripts/script/install_remote
@@ -30,13 +30,15 @@ docs::parse "$@"
 
 # Save current working directory to return user there
 STARTING_DIRECTORY="$(pwd)"
-CURL_BIN="$(which curl)"
+CURL_BIN="$(command -v curl)"
 
-# Script name if provided if not with downloaded name
-[[ -n $script_name ]] && script_name_args="-o $script_name" || script_name_args=${script_name:-"-O"}
-
-# Download command
-download_command="$CURL_BIN -k -L -f -q $script_name_args"
+# Build curl arguments as an array (avoids eval — prevents command injection via URL)
+curl_args=("$CURL_BIN" -k -L -f -q)
+if [[ -n "${script_name:-}" ]]; then
+  curl_args+=(-o "$script_name")
+else
+  curl_args+=(-O)
+fi
 
 # Scripts context directory
 { [[ -z "${context:-}" ]] || [[ -z "${script_raw_url:-}" ]]; } && output::error "Error no context or script name." && exit 1
@@ -48,12 +50,14 @@ cd "$dotfiles_context" || exit 1
 
 # Download the script
 output::write "Downloading the script ⚡️"
-eval "$download_command $script_raw_url"
-if [ ! $? ]; then
-  if [ -z "$(ls -A "$dotfiles_context" 2> /dev/null)" ]; then
+"${curl_args[@]}" "$script_raw_url"
+curl_exit=$?
+if [[ $curl_exit -ne 0 ]]; then
+  if [[ -z "$(ls -A "$dotfiles_context" 2> /dev/null)" ]]; then
     output::error "The context '$dotfiles_context' is empty. File could not be downloaded."
     exit 1
   fi
+fi
 fi
 
 # Getting the name

--- a/scripts/script/install_remote
+++ b/scripts/script/install_remote
@@ -58,7 +58,6 @@ if [[ $curl_exit -ne 0 ]]; then
     exit 1
   fi
 fi
-fi
 
 # Getting the name
 #shellcheck disable=SC2012


### PR DESCRIPTION
## Summary

Replace `eval "$download_command $script_raw_url"` with a proper array-based invocation to eliminate the command injection vector.

## Changes

- Replace string-based command building with a bash array (`curl_args`)
- Replace `eval` with direct array expansion: `"${curl_args[@]}" "$script_raw_url"`
- Fix exit code capture: `$?` was consumed by `[` command, now captured immediately as `curl_exit=$?`
- Replace `which curl` with `command -v curl` (POSIX compliance)

## Security impact

The `script_raw_url` argument to `dot script install_remote <context> <url>` was previously passed through `eval`, allowing shell metacharacter injection (e.g. `; rm -rf ~`, `$(cmd)`, `` `cmd` ``). It is now passed as a single quoted argument to curl.

## Verification

- `bash scripts/core/static_analysis` ✓
- `bash scripts/core/lint` ✓
- `make test` — 62 tests ✓

Closes #288
