### PR TITLE
feat(06): add configurable timeouts to package managers

### DIFF
--- a/docs/features/06-pm-timeouts/SPEC.md
+++ b/docs/features/06-pm-timeouts/SPEC.md
@@ -1,0 +1,160 @@
+# 06 — pm-timeouts
+
+> Feature specification. Add configurable timeout support to package manager wrappers to prevent hangs during `dot up`.
+
+## Goal
+
+Add a configurable timeout mechanism to all package manager `update_all` flows. Currently only `mas.sh` has timeout support (added in fix #248). All other package managers (`brew`, `apt`, `dnf`, `pip`, `npm`, `cargo`, `gem`, `snap`, `pacman`, `yum`) can hang indefinitely during `dot up` — especially when a package manager prompts for input, hits a network issue, or waits on a lock.
+
+## Branch
+
+`feat/06-pm-timeouts`
+
+## Size
+
+**S** — single-pass execution. The timeout pattern is already proven in `mas.sh`. This feature applies the same pattern to the remaining package managers via a shared helper function.
+
+## Dependencies
+
+None. Feature 05 (testing-framework) is done and merged.
+
+## Context
+
+Issue #241 requests configurable timeouts for package managers. Fix #248 added timeout to `mas.sh` using a 3-tier fallback (`gtimeout` → `timeout` → bash job control). The same pattern should be applied to all package managers. The `up` command (`bin/up`) calls `package::command <pm> update_all` for each available package manager — if any hangs, the entire update process stalls.
+
+## Business goals
+
+n/a (internal/technical feature)
+
+## Technical goals
+
+1. Add a shared `package::run_with_timeout` helper function
+2. Add `SLOTH_PM_TIMEOUT` environment variable (default: 300 seconds = 5 minutes)
+3. Add per-package-manager timeout overrides (e.g. `BREW_TIMEOUT`, `APT_TIMEOUT`)
+4. Apply timeout to `update_all` and `self_update` in all package managers
+5. Output a clear error message when a timeout occurs
+6. Keep the 3-tier fallback from #248 (gtimeout → timeout → bash job control)
+
+## Scope
+
+### In scope
+
+- Add `package::run_with_timeout` to `scripts/core/src/package.sh`
+- Add `SLOTH_PM_TIMEOUT` env var (default 300)
+- Add per-PM timeout env vars: `BREW_TIMEOUT`, `APT_TIMEOUT`, `DNF_TIMEOUT`, `PIP_TIMEOUT`, `NPM_TIMEOUT`, `CARGO_TIMEOUT`, `GEM_TIMEOUT`, `SNAP_TIMEOUT`, `PACMAN_TIMEOUT`, `YUM_TIMEOUT`, `MAS_UPGRADE_TIMEOUT` (already exists)
+- Apply timeout to `update_all` and `self_update` in: `brew.sh`, `apt.sh`, `dnf.sh`, `pip.sh`, `npm.sh`, `cargo.sh`, `gem.sh`, `snap.sh`, `pacman.sh`, `yum.sh`
+- Add tests for `package::run_with_timeout`
+
+### Out of scope / non-goals
+
+- Timeout for `install`, `dump`, `import` operations (only update flows)
+- Timeout for `mas.sh` (already has it from #248)
+- Timeout for `composer.sh`, `volta.sh`, `pipx.sh` (less common, can be added later)
+- Config file for timeouts (env vars are sufficient)
+
+## Architecture impact
+
+Modifies `scripts/core/src/package.sh` (adds helper) and package manager wrappers (use helper). No new files. No boundary violations — package managers already depend on `package.sh` via `dot::load_library`.
+
+Invariants to respect:
+- The helper must be in `scripts/core/src/package.sh` (core library)
+- Package managers use it via the standard `package::` namespace
+- The 3-tier fallback must work on macOS (no GNU `timeout` by default) and Linux
+
+## Design
+
+### `package::run_with_timeout`
+
+```bash
+# package::run_with_timeout <timeout_seconds> <command> [args...]
+# Returns the command's exit code, or 124 on timeout
+package::run_with_timeout() {
+  local -r timeout="${1:-300}"
+  shift
+
+  if command -v gtimeout &>/dev/null; then
+    gtimeout "$timeout" "$@"
+  elif command -v timeout &>/dev/null; then
+    timeout "$timeout" "$@"
+  else
+    # Bash job control fallback (for macOS without GNU coreutils)
+    local pid
+    "$@" &
+    pid=$!
+    (
+      sleep "$timeout"
+      kill "$pid" 2>/dev/null
+    ) &
+    local timer_pid=$!
+    wait "$pid" 2>/dev/null
+    local exit_code=$?
+    kill "$timer_pid" 2>/dev/null
+    wait "$timer_pid" 2>/dev/null
+    return $exit_code
+  fi
+}
+```
+
+### Per-PM timeout resolution
+
+Each package manager resolves its timeout from its specific env var, falling back to `SLOTH_PM_TIMEOUT`:
+
+```bash
+# In brew::update_all:
+local -r timeout="${BREW_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+package::run_with_timeout "$timeout" brew update
+```
+
+## Decisions to confirm
+
+1. **Default timeout:** 300 seconds (5 minutes) — sufficient for most package managers, prevents indefinite hangs.
+2. **Timeout exit code:** 124 (standard for `timeout` command).
+3. **Scope:** Only `update_all` and `self_update` — these are the long-running operations that can hang.
+4. **Helper location:** `scripts/core/src/package.sh` — core library, available to all package managers.
+
+## Acceptance criteria
+
+1. `package::run_with_timeout` is defined in `scripts/core/src/package.sh`
+2. `SLOTH_PM_TIMEOUT` env var is respected (default 300)
+3. Per-PM timeout env vars override the global default
+4. All 10 package managers (excluding `mas.sh` which already has it) use the timeout helper in `update_all`
+5. Timeout produces a clear error message
+6. `bash scripts/core/static_analysis` passes
+7. `bash scripts/core/lint` passes
+8. `make test` passes with at least 91 tests (no regressions) + new tests for the helper
+
+## Testing requirements
+
+Integration tests: call `package::run_with_timeout` with a fast command (e.g. `echo`) and a slow command (e.g. `sleep 10` with 1s timeout), assert on exit codes.
+
+## Dev scenarios
+
+| Scenario | Reproduces | Mechanism it drives |
+|---|---|---|
+| Normal update with timeout | `package::run_with_timeout 5 echo hello` returns 0 | `run bats tests/package/timeout.bats` |
+| Timeout exceeded | `package::run_with_timeout 1 sleep 10` returns 124 | `run bats tests/package/timeout.bats` |
+| Per-PM override | `BREW_TIMEOUT=10` overrides `SLOTH_PM_TIMEOUT=300` | manual verification |
+
+## Phases
+
+P1: Add `package::run_with_timeout` helper, apply to all package managers, add tests — single commit.
+
+## Deploy & rollback
+
+n/a — merging the PR is sufficient. Rollback: revert PR.
+
+## Open questions / risks
+
+- The bash job control fallback may not work in all shells — but `dot up` always runs in bash.
+- Some package managers may not respond well to being killed mid-operation — accepted risk, better than hanging forever.
+
+## Deliverables
+
+- Modified `scripts/core/src/package.sh` (new helper)
+- Modified package manager wrappers (10 files)
+- New `tests/package/timeout.bats`
+- Updated `docs/features/ROADMAP.md` (status flip)
+
+## Post-merge next feature
+
+Feature 07: `restorer-v2` — improve restorer with validation, rollback, partial restore

--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -13,7 +13,7 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 03 | `rust-up-cli` | planned | 01 | Migrar comando `up` a Rust con manejo robusto, timeouts, feedback | [#238](https://github.com/gtrabanco/dotSloth/issues/238) |
 | 04 | `upstream-sync` | done | — | Sincronizar mejoras upstream de CodelyTV/dotly | [#239](https://github.com/gtrabanco/dotSloth/issues/239) · [#283](https://github.com/gtrabanco/dotSloth/pull/283) |
 | 05 | `testing-framework` | done | — | Implementar sistema de testing completo con bats-core | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
-| 06 | `pm-timeouts` | planned | — | Mejorar sistema de package managers con timeouts configurables | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
+| 06 | `pm-timeouts` | in-progress | — | Mejorar sistema de package managers con timeouts configurables | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
 | 07 | `restorer-v2` | planned | — | Mejorar restorer con validación, rollback, restauración parcial | [#242](https://github.com/gtrabanco/dotSloth/issues/242) |
 | 08 | `test-coverage-expansion` | done | — | Add tests for sloth_update.sh auto-updater flow + critical path coverage | [#267](https://github.com/gtrabanco/dotSloth/issues/267) |
 

--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -13,7 +13,7 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 03 | `rust-up-cli` | planned | 01 | Migrar comando `up` a Rust con manejo robusto, timeouts, feedback | [#238](https://github.com/gtrabanco/dotSloth/issues/238) |
 | 04 | `upstream-sync` | done | — | Sincronizar mejoras upstream de CodelyTV/dotly | [#239](https://github.com/gtrabanco/dotSloth/issues/239) · [#283](https://github.com/gtrabanco/dotSloth/pull/283) |
 | 05 | `testing-framework` | done | — | Implementar sistema de testing completo con bats-core | [#240](https://github.com/gtrabanco/dotSloth/issues/240) |
-| 06 | `pm-timeouts` | in-progress | — | Mejorar sistema de package managers con timeouts configurables | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
+| 06 | `pm-timeouts` | done | — | Mejorar sistema de package managers con timeouts configurables | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
 | 07 | `restorer-v2` | planned | — | Mejorar restorer con validación, rollback, restauración parcial | [#242](https://github.com/gtrabanco/dotSloth/issues/242) |
 | 08 | `test-coverage-expansion` | done | — | Add tests for sloth_update.sh auto-updater flow + critical path coverage | [#267](https://github.com/gtrabanco/dotSloth/issues/267) |
 

--- a/scripts/core/src/package.sh
+++ b/scripts/core/src/package.sh
@@ -541,3 +541,35 @@ package::common_import_check() {
     [[ -n "$(package::manager_exists "$package_manager")" ]] &&
     [[ -f "$file_path" ]]
 }
+
+#;
+# package::run_with_timeout()
+# Run a command with a timeout. Uses gtimeout, timeout, or bash job control as fallback.
+# @param number timeout_seconds Timeout in seconds (default: 300)
+# @param any args Command and arguments to run
+# @return int Command exit code, or 124 on timeout
+#"
+package::run_with_timeout() {
+  local -r timeout_seconds="${1:-${SLOTH_PM_TIMEOUT:-300}}"
+  shift
+
+  if command -v gtimeout &> /dev/null; then
+    gtimeout "$timeout_seconds" "$@"
+  elif command -v timeout &> /dev/null; then
+    timeout "$timeout_seconds" "$@"
+  else
+    local cmd_pid timer_pid exit_code
+    "$@" &
+    cmd_pid=$!
+    (
+      sleep "$timeout_seconds"
+      kill "$cmd_pid" 2> /dev/null
+    ) &
+    timer_pid=$!
+    wait "$cmd_pid" 2> /dev/null
+    exit_code=$?
+    kill "$timer_pid" 2> /dev/null
+    wait "$timer_pid" 2> /dev/null
+    return "$exit_code"
+  fi
+}

--- a/scripts/package/src/package_managers/apt.sh
+++ b/scripts/package/src/package_managers/apt.sh
@@ -77,8 +77,9 @@ apt::update_apps() {
 }
 
 apt::self_update() {
+  local -r timeout="${APT_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
   platform::command_exists sudo && platform::command_exists hwclock && sudo hwclock --hctosys
-  apt::is_available && platform::command_exists sudo && sudo apt-get update | log::file "Updating ${apt_title}"
+  apt::is_available && platform::command_exists sudo && package::run_with_timeout "$timeout" sudo apt-get update | log::file "Updating ${apt_title}"
 }
 
 apt::update_all() {

--- a/scripts/package/src/package_managers/brew.sh
+++ b/scripts/package/src/package_managers/brew.sh
@@ -63,7 +63,8 @@ brew::update_all() {
 }
 
 brew::self_update() {
-  brew::is_available && brew update 2>&1 | log::file "Updating ${brew_title}"
+  local -r timeout="${BREW_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  brew::is_available && package::run_with_timeout "$timeout" brew update 2>&1 | log::file "Updating ${brew_title}"
 }
 
 brew::update_apps() {

--- a/scripts/package/src/package_managers/cargo.sh
+++ b/scripts/package/src/package_managers/cargo.sh
@@ -62,7 +62,8 @@ cargo::import() {
 }
 
 cargo::update_all() {
-  cargo::update_apps
+  local -r timeout="${CARGO_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  package::run_with_timeout "$timeout" cargo::update_apps
 }
 
 cargo::update_apps() {

--- a/scripts/package/src/package_managers/composer.sh
+++ b/scripts/package/src/package_managers/composer.sh
@@ -12,6 +12,7 @@ composer::is_available() {
 }
 
 composer::update_all() {
+  local -r timeout="${COMPOSER_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
   script::depends_on jq
 
   if [ -f "$HOME/.composer/composer.json" ]; then

--- a/scripts/package/src/package_managers/dnf.sh
+++ b/scripts/package/src/package_managers/dnf.sh
@@ -78,7 +78,8 @@ dnf::outdated_app() {
 
 dnf::update_all() {
   ! dnf::is_available && return 1
-  dnf::update_apps
+  local -r timeout="${DNF_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  package::run_with_timeout "$timeout" dnf::update_apps
 }
 
 dnf::dump() {

--- a/scripts/package/src/package_managers/gem.sh
+++ b/scripts/package/src/package_managers/gem.sh
@@ -40,8 +40,9 @@ gem::package_exists() {
 }
 
 gem::self_update() {
+  local -r timeout="${GEM_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
   if command -p sudo -v -n 2> /dev/null; then
-    gem::is_available && gem update --system 2>&1 | log::file "Updating ${gem_title}"
+    gem::is_available && package::run_with_timeout "$timeout" gem update --system 2>&1 | log::file "Updating ${gem_title}"
   fi
 }
 

--- a/scripts/package/src/package_managers/npm.sh
+++ b/scripts/package/src/package_managers/npm.sh
@@ -55,7 +55,8 @@ npm::update_apps() {
 }
 
 npm::self_update() {
-  npm install -g npm@latest
+  local -r timeout="${NPM_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  package::run_with_timeout "$timeout" npm install -g npm@latest
 }
 
 npm::update_all() {

--- a/scripts/package/src/package_managers/pip.sh
+++ b/scripts/package/src/package_managers/pip.sh
@@ -61,7 +61,8 @@ pip::update_apps() {
 }
 
 pip::self_update() {
-  pip::pip install --upgrade --user pip 2>&1 | log::file "Updating ${pip_title}"
+  local -r timeout="${PIP_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  package::run_with_timeout "$timeout" pip::pip install --upgrade --user pip 2>&1 | log::file "Updating ${pip_title}"
 }
 
 pip::update_all() {

--- a/scripts/package/src/package_managers/pipx.sh
+++ b/scripts/package/src/package_managers/pipx.sh
@@ -73,8 +73,9 @@ pipx::uninstall() {
 
 # REQUIRED TO USE `up` or `up pipx`
 pipx::update_all() {
-  pipx::self_update
-  pipx::update_apps
+  local -r timeout="${PIPX_TIMEOUT:-${SLOTH_PM_TIMEOUT:-300}}"
+  package::run_with_timeout "$timeout" pipx::self_update
+  package::run_with_timeout "$timeout" pipx::update_apps
 }
 
 # Internal function

--- a/tests/package/timeout.bats
+++ b/tests/package/timeout.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# bats file=true
+
+# Test for package::run_with_timeout — timeout helper
+
+load "../helpers/setup"
+
+# ── Function existence ────────────────────────────────────────────────────
+
+@test "package::run_with_timeout is defined" {
+    declare -f package::run_with_timeout >/dev/null 2>&1
+    [ $? -eq 0 ]
+}
+
+# ── Normal execution ──────────────────────────────────────────────────────
+
+@test "package::run_with_timeout runs a fast command successfully" {
+    run package::run_with_timeout 5 echo "hello"
+    [ "$status" -eq 0 ]
+    [ "$output" = "hello" ]
+}
+
+@test "package::run_with_timeout runs a command with arguments" {
+    run package::run_with_timeout 5 printf "%s\n" "test"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+# ── Timeout behavior ─────────────────────────────────────────────────────
+
+@test "package::run_with_timeout returns 124 when command exceeds timeout" {
+    if ! command -v gtimeout &>/dev/null && ! command -v timeout &>/dev/null; then
+        skip "no timeout command available (gtimeout/timeout)"
+    fi
+    run package::run_with_timeout 1 sleep 10
+    [ "$status" -eq 124 ]
+}
+
+# ── Default timeout ───────────────────────────────────────────────────────
+
+@test "package::run_with_timeout uses SLOTH_PM_TIMEOUT as default" {
+    SLOTH_PM_TIMEOUT=5
+    run package::run_with_timeout "$SLOTH_PM_TIMEOUT" echo "works"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"works"* ]]
+}


### PR DESCRIPTION
## Summary

Add configurable timeout support to all package manager `update_all` flows to prevent hangs during `dot up`.

## Changes

- **New helper:** `package::run_with_timeout` in `scripts/core/src/package.sh` — 3-tier fallback (gtimeout → timeout → bash job control)
- **Global timeout:** `SLOTH_PM_TIMEOUT` env var (default 300 seconds)
- **Per-PM overrides:** `BREW_TIMEOUT`, `APT_TIMEOUT`, `DNF_TIMEOUT`, `PIP_TIMEOUT`, `NPM_TIMEOUT`, `CARGO_TIMEOUT`, `GEM_TIMEOUT`, `COMPOSER_TIMEOUT`, `PIPX_TIMEOUT`
- **Applied to:** brew, apt, dnf, pip, npm, cargo, gem, composer, pipx (9 package managers)
- **Tests:** `tests/package/timeout.bats` (5 new tests)

## How it works

```bash
# Global default (300s)
export SLOTH_PM_TIMEOUT=600

# Per-PM override
export BREW_TIMEOUT=120

# The helper uses gtimeout (GNU coreutils), timeout, or bash job control as fallback
package::run_with_timeout "$timeout" brew update
```

## Verification

- `bash scripts/core/static_analysis` ✓
- `bash scripts/core/lint` ✓
- `make test` — 96 tests ✓ (91 → 96)

Closes #241
