### PR TITLE
docs: remove stale #288 from fix index

### DIFF
--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| 288-eval-injection | eval with user-provided URL is a command injection vector | in-progress | — | [#288](https://github.com/gtrabanco/dotSloth/issues/288) |
+| (none) | | | | |
 
 ## Conventions
 


### PR DESCRIPTION
## What & why

Removes the stale #288 entry from the fix index. PR #292 merged and issue #288 is closed, but the fix index row was never removed. This is a docs-only cleanup.

## Linked issue

n/a (docs hygiene)

## Type

- [ ] Feature
- [ ] Fix
- [x] Chore / docs

## Checklist

- [x] Branch is off `main` and the PR targets `main`
- [x] Verification gate passes (docs-only change, no code)
- [x] No architecture/dependency-rule violations
- [x] No secrets committed
- [x] Docs updated where the documentation map requires it
- [x] User-facing limitations disclosed

## Notes for the reviewer

Trivial docs-only change — removes one stale row from `docs/fix/README.md`.
