### PR TITLE
feat(09): mock harness for external commands

### DIFF
--- a/docs/features/09-mock-harness/REVIEW.md
+++ b/docs/features/09-mock-harness/REVIEW.md
@@ -1,0 +1,21 @@
+# Review Report — Feature 09 (mock-harness)
+
+**Date:** 2026-07-06
+**Branch:** `feat/09-mock-harness`
+**Commits:** `afa794d` (docs), `c8363b6` (implementation)
+**Gate:** static_analysis ✓, lint ✓, 105 tests ✓ (96 + 9 new)
+
+## Summary
+
+Added a mock harness for external commands in the test suite. The harness provides `mock_command`, `unmock_command`, `clear_mocks`, and `is_mocked` functions. Mocks are created as bash scripts in `tests/helpers/mocks/` (prepended to PATH by setup.bash). Also fixed a latent PATH bug in setup.bash (was using relative paths instead of `SLOTH_PATH`).
+
+## Findings
+
+| # | Severity | Finding | Disposition |
+|---|----------|---------|-------------|
+| 1 | INFO | setup.bash PATH was relative — fixed to use SLOTH_PATH | No action (bug fix) |
+| 2 | INFO | mocks.sh (old file) still exists but is deprecated | No action (backward compat) |
+
+## Verdict
+
+No fix-now findings. Gate green. Implementation matches SPEC.

--- a/docs/features/09-mock-harness/SPEC.md
+++ b/docs/features/09-mock-harness/SPEC.md
@@ -1,0 +1,124 @@
+# 09 — mock-harness
+
+> Feature specification. Mock harness for external commands in the test suite.
+
+## Goal
+
+Create a reusable mock harness that lets tests stub external commands (`gem`, `brew`, `git`, `npm`, etc.) with configurable exit codes and output. This unblocks functional tests for package managers (#273), bootstrap scripts (#268), and core libraries that shell out.
+
+## Branch
+
+`feat/09-mock-harness`
+
+## Size
+
+**S** — single helper file + mock directory + tests.
+
+## Dependencies
+
+None.
+
+## Context
+
+Issue #302 (filed from product audit). The test setup (`tests/helpers/setup.bash`) already prepends `tests/helpers/mocks` to PATH, but that directory doesn't exist. The `mocks.sh` file defines mock functions but they're not usable as PATH-based stubs. Current tests for package managers use grep-based regression guards (#273) because there's no way to mock the external `gem`/`brew`/`dnf` commands.
+
+## Scope
+
+### In scope
+
+- Create `tests/helpers/mocks/` directory (referenced by setup.bash but missing)
+- Create `tests/helpers/mock.sh` — a sourceable library with:
+  - `mock_command <cmd> [--exit-code N] [--stdout "text"] [--stderr "text"]` — creates a mock binary in the mocks dir
+  - `mock_command_script <cmd> <script_path>` — creates a mock from a script file
+  - `unmock_command <cmd>` — removes a mock binary
+  - `clear_mocks` — removes all mocks
+- Tests for the mock harness itself (`tests/helpers/mock_test.bats`)
+- Update `tests/helpers/setup.bash` to source the mock library
+- Keep existing `mocks.sh` for backward compatibility (deprecated)
+
+### Out of scope
+
+- Rewriting existing tests to use mocks (tracked in #273, #268, feature 10)
+- Mocking complex command interactions (stateful mocks, call counters) — keep it simple first
+
+## Design
+
+### `mock_command`
+
+Creates a simple bash script in `tests/helpers/mocks/` that outputs fixed text and exits with a fixed code:
+
+```bash
+mock_command() {
+  local cmd="$1"
+  shift
+  local exit_code=0
+  local stdout=""
+  local stderr=""
+  
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --exit-code) exit_code="$2"; shift 2 ;;
+      --stdout) stdout="$2"; shift 2 ;;
+      --stderr) stderr="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  
+  local mock_path="${MOCK_DIR:-$(dirname "${BASH_SOURCE[0]}")/mocks}/$cmd"
+  mkdir -p "$(dirname "$mock_path")"
+  cat > "$mock_path" << MOCK
+#!/usr/bin/env bash
+[[ -n "$stderr" ]] && echo "$stderr" >&2
+[[ -n "$stdout" ]] && echo "$stdout"
+exit $exit_code
+MOCK
+  chmod +x "$mock_path"
+}
+```
+
+### `unmock_command`
+
+```bash
+unmock_command() {
+  local cmd="$1"
+  local mock_path="${MOCK_DIR:-$(dirname "${BASH_SOURCE[0]}")/mocks}/$cmd"
+  rm -f "$mock_path"
+}
+```
+
+### `clear_mocks`
+
+```bash
+clear_mocks() {
+  local mock_dir="${MOCK_DIR:-$(dirname "${BASH_SOURCE[0]}")/mocks}"
+  rm -f "$mock_dir"/* 2>/dev/null || true
+}
+```
+
+## Acceptance criteria
+
+1. `tests/helpers/mocks/` directory exists
+2. `tests/helpers/mock.sh` provides `mock_command`, `unmock_command`, `clear_mocks`
+3. `mock_command gem --exit-code 1 --stdout ""` creates a mock that exits 1 with no output
+4. `mock_command brew --stdout "installed"` creates a mock that exits 0 with "installed"
+5. `unmock_command gem` removes the mock
+6. `clear_mocks` removes all mocks
+7. `tests/helpers/setup.bash` sources the mock library
+8. Tests for the mock harness pass (5+ tests)
+9. `bash scripts/core/static_analysis` passes
+10. `bash scripts/core/lint` passes
+11. `make test` passes with 96+ tests (no regressions)
+
+## Testing requirements
+
+Tests for the mock harness itself: `tests/helpers/mock_test.bats` — test `mock_command`, `unmock_command`, `clear_mocks`.
+
+## Phases
+
+Single pass (S-sized): implement mock.sh + mocks dir + tests + setup.bash update.
+
+## Open questions / risks
+
+- Mock binaries persist between tests if not cleaned up — tests should call `clear_mocks` in teardown
+- The mocks dir is in PATH (set by setup.bash) — mocks override real commands for all tests
+- bash 3.2 compatibility: no `mapfile`, use `while read` loops

--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -16,7 +16,7 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 06 | `pm-timeouts` | done | — | Mejorar sistema de package managers con timeouts configurables · [#294](https://github.com/gtrabanco/dotSloth/pull/294) | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
 | 07 | `restorer-v2` | done | — | Mejorar restorer con validación, rollback, restauración parcial · [#295](https://github.com/gtrabanco/dotSloth/pull/295) | [#242](https://github.com/gtrabanco/dotSloth/issues/242) |
 | 08 | `test-coverage-expansion` | done | — | Add tests for sloth_update.sh auto-updater flow + critical path coverage · [#293](https://github.com/gtrabanco/dotSloth/pull/293) | [#267](https://github.com/gtrabanco/dotSloth/issues/267) |
-| 09 | `mock-harness` | in-progress | — | Mock harness for external commands (unblocks #268, #273) | [#302](https://github.com/gtrabanco/dotSloth/issues/302) |
+| 09 | `mock-harness` | done | — | Mock harness for external commands (unblocks #268, #273) | [#302](https://github.com/gtrabanco/dotSloth/issues/302) |
 | 10 | `core-library-tests` | planned | 09 | Deep functional tests for core libraries (array, str, json, git) | [#301](https://github.com/gtrabanco/dotSloth/issues/301) |
 
 ## Status legend

--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -16,6 +16,8 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 06 | `pm-timeouts` | done | — | Mejorar sistema de package managers con timeouts configurables · [#294](https://github.com/gtrabanco/dotSloth/pull/294) | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
 | 07 | `restorer-v2` | done | — | Mejorar restorer con validación, rollback, restauración parcial · [#295](https://github.com/gtrabanco/dotSloth/pull/295) | [#242](https://github.com/gtrabanco/dotSloth/issues/242) |
 | 08 | `test-coverage-expansion` | done | — | Add tests for sloth_update.sh auto-updater flow + critical path coverage · [#293](https://github.com/gtrabanco/dotSloth/pull/293) | [#267](https://github.com/gtrabanco/dotSloth/issues/267) |
+| 09 | `mock-harness` | in-progress | — | Mock harness for external commands (unblocks #268, #273) | [#302](https://github.com/gtrabanco/dotSloth/issues/302) |
+| 10 | `core-library-tests` | planned | 09 | Deep functional tests for core libraries (array, str, json, git) | [#301](https://github.com/gtrabanco/dotSloth/issues/301) |
 
 ## Status legend
 

--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -16,7 +16,7 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 06 | `pm-timeouts` | done | — | Mejorar sistema de package managers con timeouts configurables · [#294](https://github.com/gtrabanco/dotSloth/pull/294) | [#241](https://github.com/gtrabanco/dotSloth/issues/241) |
 | 07 | `restorer-v2` | done | — | Mejorar restorer con validación, rollback, restauración parcial · [#295](https://github.com/gtrabanco/dotSloth/pull/295) | [#242](https://github.com/gtrabanco/dotSloth/issues/242) |
 | 08 | `test-coverage-expansion` | done | — | Add tests for sloth_update.sh auto-updater flow + critical path coverage · [#293](https://github.com/gtrabanco/dotSloth/pull/293) | [#267](https://github.com/gtrabanco/dotSloth/issues/267) |
-| 09 | `mock-harness` | done | — | Mock harness for external commands (unblocks #268, #273) | [#302](https://github.com/gtrabanco/dotSloth/issues/302) |
+| 09 | `mock-harness` | done | — | Mock harness for external commands (unblocks #268, #273) · [#303](https://github.com/gtrabanco/dotSloth/pull/303) | [#302](https://github.com/gtrabanco/dotSloth/issues/302) |
 | 10 | `core-library-tests` | planned | 09 | Deep functional tests for core libraries (array, str, json, git) | [#301](https://github.com/gtrabanco/dotSloth/issues/301) |
 
 ## Status legend

--- a/tests/helpers/mock.sh
+++ b/tests/helpers/mock.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Mock harness for external commands in tests
+# Sourceable library: provides mock_command, unmock_command, clear_mocks
+
+# Default mock directory (tests/helpers/mocks/)
+# This directory is prepended to PATH by setup.bash
+_MOCK_HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOCK_DIR="${MOCK_DIR:-${_MOCK_HARNESS_DIR}/mocks}"
+
+# Create a mock for an external command
+# Usage: mock_command <cmd> [--exit-code N] [--stdout "text"] [--stderr "text"]
+# The mock binary will output the given stdout/stderr and exit with the given code.
+mock_command() {
+  local cmd="$1"
+  shift
+
+  local exit_code=0
+  local stdout=""
+  local stderr=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --exit-code)
+        exit_code="$2"
+        shift 2
+        ;;
+      --stdout)
+        stdout="$2"
+        shift 2
+        ;;
+      --stderr)
+        stderr="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  [[ -z "$cmd" ]] && return 1
+
+  mkdir -p "$MOCK_DIR"
+  local mock_path="$MOCK_DIR/$cmd"
+
+  cat > "$mock_path" << MOCK
+#!/usr/bin/env bash
+$([[ -n "$stderr" ]] && echo "printf '%s\n' '$(echo "$stderr" | sed "s/'/'\\\\''/g")' >&2")
+$([[ -n "$stdout" ]] && echo "printf '%s\n' '$(echo "$stdout" | sed "s/'/'\\\\''/g")'")
+exit ${exit_code}
+MOCK
+  chmod +x "$mock_path"
+}
+
+# Create a mock from a script file (for complex mocks)
+# Usage: mock_command_script <cmd> <script_path>
+mock_command_script() {
+  local cmd="$1"
+  local script_path="$2"
+
+  [[ -z "$cmd" || ! -f "$script_path" ]] && return 1
+
+  mkdir -p "$MOCK_DIR"
+  cp "$script_path" "$MOCK_DIR/$cmd"
+  chmod +x "$MOCK_DIR/$cmd"
+}
+
+# Remove a mock for a specific command
+# Usage: unmock_command <cmd>
+unmock_command() {
+  local cmd="$1"
+  [[ -z "$cmd" ]] && return 1
+  rm -f "$MOCK_DIR/$cmd"
+}
+
+# Remove all mocks
+clear_mocks() {
+  [[ -d "$MOCK_DIR" ]] && rm -f "$MOCK_DIR"/* 2> /dev/null || true
+}
+
+# Check if a command is mocked
+is_mocked() {
+  local cmd="$1"
+  [[ -z "$cmd" ]] && return 1
+  [[ -f "$MOCK_DIR/$cmd" ]]
+}

--- a/tests/helpers/mock_test.bats
+++ b/tests/helpers/mock_test.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# bats file=true
+
+# Tests for the mock harness (tests/helpers/mock.sh)
+
+load "setup"
+
+setup() {
+  clear_mocks
+}
+
+teardown() {
+  clear_mocks
+}
+
+@test "mock_command is defined" {
+  declare -f mock_command >/dev/null 2>&1
+  [ $? -eq 0 ]
+}
+
+@test "unmock_command is defined" {
+  declare -f unmock_command >/dev/null 2>&1
+  [ $? -eq 0 ]
+}
+
+@test "clear_mocks is defined" {
+  declare -f clear_mocks >/dev/null 2>&1
+  [ $? -eq 0 ]
+}
+
+@test "mock_command creates a mock that exits 0 with stdout" {
+  mock_command fake_cmd --stdout "hello world"
+  run fake_cmd
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello world"* ]]
+}
+
+@test "mock_command creates a mock with custom exit code" {
+  mock_command fake_cmd --exit-code 42 --stdout "error"
+  run fake_cmd
+  [ "$status" -eq 42 ]
+  [[ "$output" == *"error"* ]]
+}
+
+@test "mock_command creates a mock with empty stdout" {
+  mock_command fake_cmd --exit-code 1 --stdout ""
+  run fake_cmd
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "unmock_command removes a mock" {
+  mock_command fake_cmd --stdout "temp"
+  run is_mocked fake_cmd
+  [ "$status" -eq 0 ]
+  unmock_command fake_cmd
+  run is_mocked fake_cmd
+  [ "$status" -ne 0 ]
+}
+
+@test "clear_mocks removes all mocks" {
+  mock_command cmd_a --stdout "a"
+  mock_command cmd_b --stdout "b"
+  clear_mocks
+  run is_mocked cmd_a
+  [ "$status" -ne 0 ]
+  run is_mocked cmd_b
+  [ "$status" -ne 0 ]
+}
+
+@test "is_mocked returns false for non-existent mock" {
+  run is_mocked nonexistent_cmd
+  [ "$status" -ne 0 ]
+}

--- a/tests/helpers/setup.bash
+++ b/tests/helpers/setup.bash
@@ -14,12 +14,16 @@ fi
 export DOTLY_PATH="${SLOTH_PATH}"
 
 # Add mocks directory to PATH (before real commands)
-# From tests/core/, helpers/mocks is at ../../helpers/mocks
-export PATH="${BATS_TEST_DIRNAME}/../../helpers/mocks:${PATH}"
+export PATH="${SLOTH_PATH}/tests/helpers/mocks:${PATH}"
 
 # Source core libraries for testing
 #shellcheck disable=SC1091
 . "${SLOTH_PATH}/scripts/core/src/_main.sh"
+
+# Source mock harness
+#shellcheck disable=SC1091
+. "${SLOTH_PATH}/tests/helpers/mock.sh"
+export MOCK_DIR="${SLOTH_PATH}/tests/helpers/mocks"
 
 # Track if we're running in CI
 if [[ -n "${CI:-}" ]]; then


### PR DESCRIPTION
## What & why

Adds a mock harness for external commands to the test suite. This enables functional tests for package managers and bootstrap scripts that previously used grep-based regression guards. The harness provides `mock_command`, `unmock_command`, `clear_mocks`, and `is_mocked` functions that create/remove bash script stubs in a PATH-prepended directory.

## Linked issue

Closes #302

## Type

- [x] Feature
- [ ] Fix
- [ ] Chore / docs

## Checklist

- [x] Branch is off `main` and the PR targets `main`
- [x] Verification gate passes (static_analysis + lint + 105 tests)
- [x] No architecture/dependency-rule violations
- [x] No secrets committed
- [x] Docs updated (SPEC + REVIEW in `docs/features/09-mock-harness/`)
- [x] User-facing limitations disclosed

## Notes for the reviewer

- `tests/helpers/mock.sh` is the main deliverable — sourceable library with 4 functions
- `tests/helpers/mocks/` directory was referenced by setup.bash but didn't exist — now created
- Fixed a latent bug in setup.bash: PATH was using relative paths instead of `SLOTH_PATH`
- 9 new tests in `tests/helpers/mock_test.bats`
- Unblocks #268 (restorer/installer tests) and #273 (gem.bats functional tests)
- Feature 10 (core-library-tests) depends on this
