### PR TITLE
fix(package): unlink Go yq before installing python-yq on macOS

### DIFF
--- a/docs/fix/306-python-yq-brew-conflict/SPEC.md
+++ b/docs/fix/306-python-yq-brew-conflict/SPEC.md
@@ -1,0 +1,113 @@
+# fix/306-python-yq-brew-conflict
+
+> Fix specification. Copy this folder to `docs/fix/<issue-number>-<topic>/`, fill
+> every section, and register the entry in `docs/fix/README.md`. Lighter than a
+> feature spec — no planning artifacts. The SPEC alone is the source of truth.
+
+## Goal
+
+Repair `python-yq::install` so it succeeds on macOS hosts where the Go `yq`
+formula (mikefarah/yq) is already installed via Homebrew. The current recipe
+calls `brew install python-yq` directly, which Homebrew rejects with a formula
+conflict (both ship a `yq` executable), aborting the symlinks step and cascading
+into the zim install. This cannot wait for a feature cycle because it breaks the
+installer on the current macOS GitHub Actions runner image, which now ships the
+Go `yq` preinstalled.
+
+## Issue
+
+`#306` — tracked issue. Required. The PR must close it.
+
+## Branch
+
+`fix/306-python-yq-brew-conflict`
+
+## Root cause
+
+`scripts/package/src/recipes/python-yq.sh:27` (pre-fix) runs
+`brew install python-yq` while the Go `yq` formula is linked. Homebrew refuses:
+
+```
+Cannot install python-yq because conflicting formulae are installed.
+  yq: because both install `yq` executables
+Please `brew unlink yq` before continuing.
+```
+
+The pip fallback (`scripts/package/src/recipes/python-yq.sh:36`,
+`python3 -m pip install --user --no-cache-dir yq`) then trips PEP 668
+(`externally-managed-environment`) on the externally-managed macOS Python, so
+both install paths fail and the recipe returns 1. The symlinks step aborts and
+zim cannot source `~/.zimrc`.
+
+Evidence: CI run 28825710882, job `🚀 Build (macos-latest)` —
+https://github.com/gtrabanco/dotSloth/actions/runs/28825710882/job/85488175049
+
+The project requires kislyuk/yq (python-yq) specifically — see
+`python-yq::is_installed` (`yq --help | grep kislyuk`) and the `yq -r '.'` usage
+in `scripts/core/src/yaml.sh` — so replacing the active `yq` is intended, not a
+side effect.
+
+## Scope
+
+### In scope
+
+`scripts/package/src/recipes/python-yq.sh` only: unlink the Go `yq` formula
+before `brew install python-yq` and `brew reinstall python-yq`.
+
+### Out of scope
+
+- PEP 668 in the pip fallback path — only reached when brew is absent; the brew
+  path now succeeds on macOS, so the pip fallback is not exercised in CI. A
+  separate issue could add `--break-system-packages` handling if needed.
+- Choosing between Go `yq` and python-yq globally — out of scope; the project
+  already mandates python-yq.
+
+## Impact
+
+- Modules/files touched: `scripts/package/src/recipes/python-yq.sh`.
+- Blast radius: if the unlink is wrong, `brew install python-yq` could still
+  fail or the user's Go `yq` could be left unlinked. The unlink is guarded by
+  `brew list --versions yq` (only fires when the Go formula is installed) and is
+  reversible with `brew link yq`. No change on Linux/FreeBSD or on macOS without
+  the Go `yq`.
+- Detection lead time: immediate — CI `🚀 Build (macos-latest)` surfaces it on
+  the next run.
+
+## Rules that must never be violated
+
+- Cross-platform guards: brew is only invoked through `platform::command_exists
+  brew` (preserved).
+- Shell compatibility: no bashisms; `> /dev/null 2>&1`, `|| true`, and the `if`
+  guard are POSIX-compatible and safe on macOS bash 3.2.
+- No new dependencies.
+- Recipe namespace convention: helper is `python-yq::_unlink_conflicting_yq`.
+
+## Risks
+
+- Operational: a user who intentionally uses the Go `yq` will find it unlinked
+  after running the installer. Mitigation: the change only runs during
+  `python-yq::install`, is reversible (`brew link yq`), and the project
+  mandates python-yq anyway.
+- Security: n/a — no privilege change, no network, no secret handling.
+- Compliance: n/a.
+
+## Acceptance criteria
+
+- [x] `./scripts/core/lint` green (shfmt) — verified with shfmt v3.11.0,
+      `-ln bash -sr -ci -i 2 -d` returns no diff.
+- [x] `./scripts/core/static_analysis` green (shellcheck) — verified with
+      shellcheck v0.10.0, `-s bash -S warning -e SC1090 -e SC2010 -e SC2154`
+      returns clean.
+- [ ] `python-yq::install` succeeds on a macOS runner with the Go `yq` formula
+      preinstalled — CI `🚀 Build (macos-latest)` passes on the fix PR. (Pending
+      CI run on the PR.)
+
+## Rollback
+
+Revert the commit. No data-side cleanup: `brew unlink yq` only removes
+Homebrew symlinks for the Go `yq`, restored with `brew link yq`. python-yq, once
+installed, is unaffected by a revert.
+
+## Effort
+
+XS — single-file, ~10-line additive change with a guarded, reversible helper.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| (none) | | | | |
+| 306-python-yq-brew-conflict | python-yq install fails on macOS when Go yq formula is installed | in-progress | — | #306 |
 
 ## Conventions
 

--- a/scripts/package/src/recipes/python-yq.sh
+++ b/scripts/package/src/recipes/python-yq.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
 
+# The Go `yq` (mikefarah/yq) and `python-yq` (kislyuk/yq) both ship a `yq`
+# executable, so Homebrew refuses to install python-yq while the Go yq is
+# linked ("Cannot install python-yq because conflicting formulae are
+# installed"). Unlink the Go yq first; reversible with `brew link yq`.
+python-yq::_unlink_conflicting_yq() {
+  if platform::command_exists brew && brew list --versions yq > /dev/null 2>&1; then
+    brew unlink yq > /dev/null 2>&1 || true
+  fi
+  return 0
+}
+
 python-yq::install() {
   script::depends_on python3-pip
 
   if [[ -n "${1:-}" && $1 == "--force" ]] && python-yq::is_installed; then
     if platform::command_exists brew; then
+      python-yq::_unlink_conflicting_yq
       brew reinstall python-yq
 
     elif
@@ -24,6 +36,7 @@ python-yq::install() {
   if
     ! python-yq::is_installed &&
       platform::command_exists brew &&
+      python-yq::_unlink_conflicting_yq &&
       brew install python-yq &&
       python-yq::is_installed
   then


### PR DESCRIPTION
<!--
One PR per unit of work, always against `main`. Must be independently mergeable.
Never stack PRs.
-->

## What & why

`python-yq::install` calls `brew install python-yq` directly. On macOS hosts
where the Go `yq` formula (mikefarah/yq) is already linked, Homebrew refuses
with a formula conflict (both ship a `yq` executable); the pip fallback then
trips PEP 668 (`externally-managed-environment`), so both install paths fail,
the symlinks step aborts, and zim cannot source `~/.zimrc`. The current macOS
GitHub Actions runner image (`macos-26-arm64`, 20260630.0213.1) now ships the
Go `yq` preinstalled, which triggers this on every macOS Build job.

This PR unlinks the Go `yq` first (guarded by `brew list --versions yq`,
reversible with `brew link yq`) before `brew install python-yq` and
`brew reinstall python-yq`. The project requires kislyuk/yq (python-yq)
specifically — see `python-yq::is_installed` and `yq -r '.'` in
`scripts/core/src/yaml.sh` — so replacing the active `yq` is intended. No
change on Linux/FreeBSD or on macOS without the Go `yq`.

This is the root cause of the `🚀 Build (macos-latest)` failure observed on
PR #305 (run 28825710882) — unrelated to that PR's 4-line stub.

## Linked issue

Closes #306

## Type

- [ ] Feature
- [x] Fix
- [ ] Chore / docs

## Checklist

- [x] Branch is off `main` and the PR targets `main`
- [x] Verification gate passes (shfmt + shellcheck green on the changed file)
- [x] No architecture/dependency-rule violations (see `docs/architecture/ARCHITECTURE.md`)
- [x] No secrets committed
- [x] Docs updated where the documentation map requires it (`docs/fix/306-python-yq-brew-conflict/SPEC.md`, `docs/fix/README.md`)
- [x] User-facing limitations disclosed (a user intentionally on the Go `yq` will find it unlinked after install; reversible with `brew link yq`)

## Notes for the reviewer

- Single-file code change: `scripts/package/src/recipes/python-yq.sh` (+10
  lines, a guarded reversible helper).
- Gate note: the repo's `./scripts/core/lint` / `./scripts/core/static_analysis`
  require the full dotly environment (`SLOTH_PATH`/`DOTFILES_PATH`) which is not
  present in a bare worktree, so the gate was verified by running the exact same
  commands the gate invokes — `shfmt -ln bash -sr -ci -i 2 -d` (v3.11.0) and
  `shellcheck -s bash -S warning -e SC1090 -e SC2010 -e SC2154` (v0.10.0) —
  directly on the changed file; both clean. CI will run the full gate.
- Acceptance criterion "macOS Build passes on the fix PR" is pending the CI run.