### PR TITLE
fix(git): add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun

### DIFF
--- a/docs/fix/308-309-git-arg-bugs/SPEC.md
+++ b/docs/fix/308-309-git-arg-bugs/SPEC.md
@@ -1,0 +1,206 @@
+# fix/308-309-git-arg-bugs
+
+> Fix specification. Copy this folder to `docs/fix/<issue-number>-<topic>/`, fill
+> every section, and register the entry in `docs/fix/README.md`. Lighter than a
+> feature spec — no planning artifacts. The SPEC alone is the source of truth.
+
+## Goal
+
+Fix two pre-existing argument-handling bugs in `scripts/core/src/git.sh` that
+were discovered during feature 10's review (PR #310). Both are silent
+wrong-behavior hazards: #309 writes to the wrong file when `$GITIGNORE_PATH`
+differs from the first argument; #308 silently drops the `-C <repo>` option
+because `$1` is consumed as a branch name. They cannot wait for a feature
+cycle because #309 has an active caller (`zimfw.sh`) that passes a path that
+may differ from `$GITIGNORE_PATH`, and #308 is a footgun for any future caller
+using the documented `-C` option form.
+
+## Issue
+
+`#308` — `git::current_commit_hash`/`check_branch_is_behind` shift `$1` as
+branch, breaking `-C` option.
+`#309` — `git::add_to_gitignore` writes to `$GITIGNORE_PATH` instead of its
+first argument.
+
+Both must be closed by this PR (`Closes #308`, `Closes #309`).
+
+## Branch
+
+`fix/308-309-git-arg-bugs`
+
+## Root cause
+
+**#309** (`scripts/core/src/git.sh:578`): `git::add_to_gitignore` declares
+`local -r gitignore_file_path="${1:-}"` (the intended target) but then appends
+to `$GITIGNORE_PATH` (a global env var) instead of `$gitignore_file_path`. When
+the two differ, content lands in the wrong file and the function returns 1
+(the subsequent `grep` on `$gitignore_file_path` finds nothing).
+
+**#308** (`scripts/core/src/git.sh:184-188`, `278-282`): `git::current_commit_hash`
+and `git::check_branch_is_behind` both do `local -r branch="${1:-HEAD}"; [[ -n
+"${1:-}" ]] && shift`. This consumes `$1` as the branch name unconditionally.
+When a caller passes `git::current_commit_hash -C <repo>`, `-C` becomes the
+"branch" and `<repo>` is passed through as a git argument — but `rev-parse`
+receives `-C` as the ref to verify, which fails or returns the wrong SHA.
+
+## Scope
+
+### In scope
+
+1. `scripts/core/src/git.sh:578` — change `tee -a "$GITIGNORE_PATH"` to
+   `tee -a "$gitignore_file_path"` (one-line fix, #309).
+2. `scripts/core/src/git.sh:184-188` (`git::current_commit_hash`) and
+   `:278-282` (`git::check_branch_is_behind`) — restructure so git options
+   (`-C`, `--git-dir`, etc.) are not consumed as the branch name. The
+   conservative fix: only shift `$1` if it does not start with `-` (i.e. it's
+   a branch/commit, not an option). If `$1` starts with `-`, leave it in `$@`
+   and use the default `HEAD` (#308).
+3. `tests/core/git.bats` — update the `add_to_gitignore` tests to use distinct
+   files for `$1` and `$GITIGNORE_PATH` (so the test would have caught the
+   bug). Update `current_commit_hash`/`check_branch_is_behind` tests to cover
+   the `-C <repo>` form without explicit `HEAD` (the form that was broken).
+
+### Out of scope
+
+- Other `git::*` functions with the same shift pattern (`git::is_valid_commit`
+  at `:192` has a similar shape but its `$1` is a commit, not a branch, and it
+  doesn't default to `HEAD` — the footgun is less severe). File a separate
+  issue if it needs fixing.
+- Refactoring the entire `git.sh` argument-parsing approach (a general
+  `git::parse_args` helper). That's a feature, not a fix.
+
+## Impact
+
+- **Modules/files touched:** `scripts/core/src/git.sh` (2 functions + 1 line),
+  `tests/core/git.bats` (3 tests updated).
+- **Blast radius:** `git::add_to_gitignore` is called by `zimfw.sh:31` and
+  `z.sh:31`. The `zimfw.sh` caller passes `${DOTFILES_PATH}/.gitignore` which
+  matches the default `GITIGNORE_PATH` — so it works today by coincidence. If
+  a user overrides `GITIGNORE_PATH`, `zimfw.sh` silently writes to the wrong
+  file. `git::current_commit_hash`/`check_branch_is_behind` have no current
+  callers in `scripts/` (only tests call them), so the fix is preventive.
+- **Detection lead time:** #309 is silent (wrong file, no error message until
+  the grep check returns 1). #308 fails with a confusing git error
+  (`rev-parse: -C: unknown ref`). Both would surface as "gitignore not
+  working" or "version check broken" user reports.
+
+## Rules that must never be violated
+
+- **Shell compatibility:** all scripts must be POSIX-compatible bash, no
+  bashisms that break on macOS bash 3.2 (CLAUDE.md hard rules). The fix uses
+  only `[[ "$1" == -* ]]` pattern matching — POSIX-safe.
+- **Core libraries are sourced, not executed** (ARCHITECTURE.md:17). The fix
+  does not add `set -euo pipefail` to `git.sh` (it's a sourced library).
+- **No new dependencies** (CLAUDE.md hard rules). The fix uses only bash
+  builtins and existing `git::git` wrapper.
+- **`command -p` for portable command resolution** (CLAUDE.md). The fix
+  doesn't add new external commands.
+
+## Risks
+
+- **Operational:** the `add_to_gitignore` fix changes where content is written
+  for callers that pass a path ≠ `$GITIGNORE_PATH`. The `zimfw.sh` caller
+  passes `${DOTFILES_PATH}/.gitignore` (== default `GITIGNORE_PATH`), so no
+  behavior change for it. The `z.sh` caller passes `$GITIGNORE_PATH` directly,
+  so no change. Risk: a hypothetical caller relying on the buggy behavior
+  (writing to `$GITIGNORE_PATH` regardless of `$1`) would break — but that's
+  the bug being fixed.
+- **Security:** n/a — no auth, secrets, PII, or network involved.
+- **Compliance:** n/a.
+
+## Acceptance criteria
+
+- [ ] `git::add_to_gitignore "$f1" "build/"` with `GITIGNORE_PATH="$f2"` (f1 ≠ f2)
+      writes "build/" to `$f1`, not `$f2`, and returns 0. (unit test,
+      `tests/core/git.bats`)
+- [ ] `git::current_commit_hash -C "$REPO_DIR"` (no explicit `HEAD`) returns
+      the HEAD SHA of `$REPO_DIR`. (unit test, `tests/core/git.bats`)
+- [ ] `git::current_commit_hash HEAD -C "$REPO_DIR"` (explicit `HEAD`) still
+      works — no regression. (unit test, existing)
+- [ ] `git::check_branch_is_behind -C "$REPO_DIR"` does not consume `-C` as
+      the branch name. (unit test, `tests/core/git.bats`)
+- [ ] `git::add_to_gitignore` existing tests (append + no-duplicate) pass with
+      distinct files. (regression, `tests/core/git.bats`)
+- [ ] `bash scripts/self/static_analysis && bash scripts/self/lint` green.
+- [ ] `make test` passes (all 158+ tests).
+
+## Rollback
+
+Revert the PR. No data-side cleanup: the fix only changes where
+`add_to_gitignore` writes content — if it wrote to the wrong file before the
+fix, that content is already there and reverting doesn't remove it. The
+`current_commit_hash` fix is pure logic — no state to clean up.
+
+## Effort
+
+**XS** — 3 one-line code changes + 3 test updates, single commit, ≤ 1h.
+
+## Impact (extra section)
+
+See above — blast radius confined to `git.sh` functions and their 2 recipe
+callers, both of which pass paths that match defaults.
+
+## Rules that must never be violated (extra section)
+
+See above.
+
+## Operational risks
+
+n/a — no scheduled jobs, queues, caches, schemas, or external adapters
+involved. `git::add_to_gitignore` is called during package installation
+(`zimfw.sh`, `z.sh`), which is interactive/user-initiated, not a background job.
+
+## Security risks
+
+n/a — no auth, secrets, PII, webhooks, or rate limits involved.
+
+## Compliance touchpoints
+
+n/a.
+
+## Affected docs
+
+- `docs/architecture/ARCHITECTURE.md` — no change needed (the fix upholds the
+  existing invariants, doesn't change them).
+- `docs/fix/README.md` — register the fix entry (status `pending`).
+
+## Observability
+
+No log line or metric — these are library functions. The fix is confirmed by
+the unit tests: `git::add_to_gitignore` writes to the correct file;
+`git::current_commit_hash -C <repo>` returns the right SHA. If the fix
+regresses, the tests fail.
+
+## Cross-issue notes
+
+- **#308 + #309** — bundled into one fix PR (same file, both small, filed
+  during the same review). The PR closes both.
+- **#300** (audit standalone scripts for `set -euo`) — unrelated; `git.sh` is
+  a sourced library, intentionally omits `set -e`.
+- **Feature 10 (#310, merged)** — added the tests that discovered both bugs.
+  The tests work around the bugs; this fix removes the workarounds.
+
+## Effort
+
+**XS** — 3 one-line code changes in `scripts/core/src/git.sh` + 3 test updates
+in `tests/core/git.bats`. Single commit, ≤ 1h.
+
+## Decisions made during drafting
+
+1. **Bundle #308 + #309** — both are in the same file, both small, both filed
+   from the same review. One PR closes both. The branch name uses both issue
+   numbers: `fix/308-309-git-arg-bugs`.
+2. **Conservative fix for #308** — only shift `$1` if it doesn't start with
+   `-` (i.e. it's a branch/commit, not an option). This preserves the existing
+   behavior for callers that pass a branch name, while fixing the `-C` case.
+   Alternative considered: a full `getopts`-based argument parser — rejected
+   as overengineering for a 2-function fix.
+3. **Test update for #309** — the existing tests point `GITIGNORE_PATH` at the
+   same file as `$1` (the workaround). The updated tests use distinct files so
+   the test would have caught the bug. This is a test improvement, not just a
+   fix verification.
+4. **`git::is_valid_commit` not in scope** — it has a similar shift pattern
+   (`:192`) but its `$1` is a commit hash, not a branch, and it doesn't
+   default to `HEAD`. The footgun is less severe (a caller passing `-C`
+   would get `cat-file -t -C` which fails loudly). Filed as out-of-scope; a
+   separate issue can be opened if needed.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| 306-python-yq-brew-conflict | python-yq install fails on macOS when Go yq formula is installed | in-progress | — | #306 |
+| 308-309-git-arg-bugs | git.sh argument bugs: add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun | pending | — | #308, #309 |
 
 ## Conventions
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| 308-309-git-arg-bugs | git.sh argument bugs: add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun | pending | — | #308, #309 |
+| 308-309-git-arg-bugs | git.sh argument bugs: add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun | done | — | #308, #309 |
 
 ## Conventions
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| 308-309-git-arg-bugs | git.sh argument bugs: add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun | done | — | #308, #309 |
+| 308-309-git-arg-bugs | git.sh argument bugs: add_to_gitignore wrong-file write + current_commit_hash/check_branch_is_behind shift footgun | done · [#313](https://github.com/gtrabanco/dotSloth/pull/313) | — | #308, #309 |
 
 ## Conventions
 

--- a/scripts/core/src/git.sh
+++ b/scripts/core/src/git.sh
@@ -182,8 +182,11 @@ git::is_clean() {
 # @param string branch Optional, by default is HEAD
 #"
 git::current_commit_hash() {
-  local -r branch="${1:-HEAD}"
-  [[ -n "${1:-}" ]] && shift
+  local branch="HEAD"
+  if [[ -n "${1:-}" && "$1" != -* ]]; then
+    branch="$1"
+    shift
+  fi
   git::git "$@" rev-parse -q --verify "${branch}"
 }
 
@@ -276,9 +279,14 @@ git::remote_latest_tag_version() {
 # @param string local_branch current branch by default
 #"
 git::check_branch_is_behind() {
-  local -r branch="${1:-$(git::current_branch "$@")}"
+  local branch
+  if [[ -n "${1:-}" && "$1" != -* ]]; then
+    branch="$1"
+    shift
+  else
+    branch="$(git::current_branch "$@")"
+  fi
   [[ -z "$branch" ]] && return 1
-  [[ -n "${1:-}" ]] && shift
 
   local -r upstream_branch="$(git::git "$@" config --get "branch.${branch}.merge" || echo -n)"
   if [[ -n "$upstream_branch" ]]; then
@@ -575,7 +583,7 @@ git::add_to_gitignore() {
   shift
 
   if [[ -n "$content" ]]; then
-    grep -q "^${content}$" "$gitignore_file_path" || echo "$content" | tee -a "$GITIGNORE_PATH" > /dev/null 2>&1
+    grep -q "^${content}$" "$gitignore_file_path" || echo "$content" | tee -a "$gitignore_file_path" > /dev/null 2>&1
     echo > /dev/null 2>&1
   fi
 

--- a/tests/core/git.bats
+++ b/tests/core/git.bats
@@ -140,9 +140,28 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
-@test "git::check_branch_is_behind with -C option (no explicit branch) does not consume -C" {
+# Distinguishing regression test: a remote ahead of local main is set up and
+# branch.main.merge is wired to the remote-tracking ref, so the fixed code
+# resolves branch=main, finds the upstream, and returns 0 (behind). Under the
+# bug, $1 (-C) is consumed as the branch name, branch.-C.merge is unset, and
+# the function returns 1 (no upstream) — so a 0 here proves -C was preserved.
+@test "git::check_branch_is_behind with -C option does not consume -C" {
+    local remote_dir
+    remote_dir=$(temp_dir)
+    git init -q -b main "$remote_dir"
+    git -C "$remote_dir" config user.email "test@test.com"
+    git -C "$remote_dir" config user.name "test"
+    git -C "$remote_dir" commit -qm "remote root" --allow-empty
+    git -C "$remote_dir" commit -qm "remote ahead" --allow-empty
+
+    git -C "$REPO_DIR" remote add origin "$remote_dir"
+    git -C "$REPO_DIR" fetch -q origin
+    git -C "$REPO_DIR" config branch.main.merge "refs/remotes/origin/main"
+
     run git::check_branch_is_behind -C "$REPO_DIR"
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 0 ]
+
+    rm -rf "$remote_dir"
 }
 
 # ── git::remote_latest_tag_version (mock tier) ─────────────────────────────

--- a/tests/core/git.bats
+++ b/tests/core/git.bats
@@ -76,6 +76,13 @@ teardown() {
     [[ "$output" =~ ^[0-9a-f]+$ ]]
 }
 
+@test "git::current_commit_hash with -C option (no explicit branch) defaults to HEAD" {
+    run git::current_commit_hash -C "$REPO_DIR"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [[ "$output" =~ ^[0-9a-f]+$ ]]
+}
+
 # ── git::local_branch_exists ────────────────────────────────────────────────
 
 @test "git::local_branch_exists returns 0 for an existing branch" {
@@ -101,33 +108,40 @@ teardown() {
 }
 
 # ── git::add_to_gitignore ───────────────────────────────────────────────────
-# NOTE: git::add_to_gitignore appends to $GITIGNORE_PATH (not to its first
-# argument $gitignore_file_path), so the test points GITIGNORE_PATH at the
-# same file to exercise the intended behavior. See the final report for the
-# noted bug.
+# Tests use distinct files for $1 and $GITIGNORE_PATH to verify the
+# function writes to its first argument, not the global $GITIGNORE_PATH.
 
-@test "git::add_to_gitignore appends content and returns 0" {
-    local gi
+@test "git::add_to_gitignore appends content to the first argument and returns 0" {
+    local gi other
     gi=$(temp_file "")
-    GITIGNORE_PATH="$gi" run git::add_to_gitignore "$gi" "build/"
+    other=$(temp_file "")
+    GITIGNORE_PATH="$other" run git::add_to_gitignore "$gi" "build/"
     [ "$status" -eq 0 ]
     grep -q "^build/$" "$gi"
-    rm -f "$gi"
+    ! grep -q "^build/$" "$other"
+    rm -f "$gi" "$other"
 }
 
 @test "git::add_to_gitignore does not duplicate already-present content" {
-    local gi
+    local gi other
     gi=$(temp_file "build/")
-    GITIGNORE_PATH="$gi" run git::add_to_gitignore "$gi" "build/"
+    other=$(temp_file "")
+    GITIGNORE_PATH="$other" run git::add_to_gitignore "$gi" "build/"
     [ "$status" -eq 0 ]
     [ "$(grep -c '^build/$' "$gi")" -eq 1 ]
-    rm -f "$gi"
+    ! grep -q "^build/$" "$other"
+    rm -f "$gi" "$other"
 }
 
 # ── git::check_branch_is_behind ─────────────────────────────────────────────
 
 @test "git::check_branch_is_behind returns 1 when no upstream is configured" {
     run git::check_branch_is_behind main -C "$REPO_DIR"
+    [ "$status" -ne 0 ]
+}
+
+@test "git::check_branch_is_behind with -C option (no explicit branch) does not consume -C" {
+    run git::check_branch_is_behind -C "$REPO_DIR"
     [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
## What & why

Fixes two pre-existing argument-handling bugs in `scripts/core/src/git.sh`,
both discovered during feature 10's review (PR #310):

- **#309** — `git::add_to_gitignore` appended content to `$GITIGNORE_PATH`
  (a global env var) instead of its first argument `$gitignore_file_path`.
  When the two differ, content lands in the wrong file and the function
  returns 1. The `zimfw.sh` caller passes `${DOTFILES_PATH}/.gitignore` which
  matches the default `GITIGNORE_PATH` — so it works by coincidence; any user
  overriding `GITIGNORE_PATH` gets a silent wrong-file write.
- **#308** — `git::current_commit_hash` and `git::check_branch_is_behind`
  consumed `$1` as the branch name unconditionally. When a caller passed
  `git::current_commit_hash -C <repo>`, `-C` became the "branch" and
  `rev-parse` received `-C` as the ref to verify, failing or returning the
  wrong SHA.

## Linked issue

Closes #308
Closes #309

## Type

- [ ] Feature
- [x] Fix
- [ ] Chore / docs

## Checklist

- [x] Branch is off `main` and the PR targets `main`
- [x] Verification gate passes (`bash scripts/self/static_analysis && bash scripts/self/lint && make test` — 157 tests, 0 fail)
- [x] No architecture/dependency-rule violations (sourced library, no `set -e`, invariants preserved)
- [x] No secrets committed
- [x] Docs updated (`docs/fix/308-309-git-arg-bugs/SPEC.md`, `docs/fix/README.md` status → done)
- [x] User-facing limitations disclosed — none; the fix changes write behavior for callers passing a path ≠ `$GITIGNORE_PATH`, but both current callers pass paths matching the default

## Notes for the reviewer

- **3 code changes in `scripts/core/src/git.sh`:**
  1. `add_to_gitignore:578` — `tee -a "$GITIGNORE_PATH"` → `tee -a "$gitignore_file_path"` (one-line fix, #309)
  2. `current_commit_hash:184-188` — restructured to only treat `$1` as a branch if it doesn't start with `-`; otherwise default to `HEAD` and pass all args to git (#308)
  3. `check_branch_is_behind:281-284` — same pattern; default to `git::current_branch "$@"` only when `$1` is empty or an option (#308)
- **3 test updates in `tests/core/git.bats`:**
  1. `add_to_gitignore` tests now use distinct files for `$1` and `$GITIGNORE_PATH` (would have caught the bug)
  2. New test: `current_commit_hash -C <repo>` (no explicit branch) defaults to HEAD
  3. New test: `check_branch_is_behind -C <repo>` does not consume `-C` as branch
- **Gate:** static_analysis + lint green; `bats --recursive tests/` 157 tests, 0 fail, 4 skip (json.bats python-yq + platform).
- **No regression risk:** both current callers (`zimfw.sh:31`, `z.sh:31`) pass paths matching defaults; the `current_commit_hash`/`check_branch_is_behind` functions had no production callers (only tests).
