### PR TITLE
fix(git): guard is_valid_commit prologue against -C footgun (#319)

### DIFF
--- a/docs/fix/319-is-valid-commit-C-option/SPEC.md
+++ b/docs/fix/319-is-valid-commit-C-option/SPEC.md
@@ -1,0 +1,46 @@
+# fix/319-is-valid-commit-C-option
+
+## Goal
+
+`git::is_valid_commit` (`scripts/core/src/git.sh:197-199`) consumes `-C` as the commit argument when a caller passes `git::is_valid_commit -C "$REPO"` (relying on the `HEAD` default), the same shift footgun fixed for `check_branch_is_behind` (#313) and `check_branch_is_ahead` (#317). This fix applies the same `[[ "$1" != -* ]]` guard.
+
+## Issue
+
+`#319`
+
+## Branch
+
+`fix/319-is-valid-commit-C-option`
+
+## Root cause
+
+```bash
+git::is_valid_commit() {
+  local -r commit="${1:-HEAD}"
+  [[ -n "${1:-}" ]] && shift
+  [[ $(git::git "$@" cat-file -t "$commit") == commit ]]
+}
+```
+
+When `$1` is `-C`, `commit` becomes `-C`, shift drops it, and `"$REPO"` becomes a bare git argument — `git "$REPO" cat-file -t "-C"` is invalid.
+
+## Scope
+
+### In scope
+
+1. `scripts/core/src/git.sh` — rewrite `is_valid_commit` prologue to mirror the fixed `check_branch_is_behind`/`check_branch_is_ahead`.
+2. `tests/core/git.bats` — distinguishing regression test: `git::is_valid_commit -C "$REPO_DIR"` with no explicit commit — fixed returns 0 (HEAD valid), buggy returns non-zero (commit=-C invalid).
+
+### Out of scope
+
+- Other git.sh issues (#315, #316).
+
+## Acceptance criteria
+
+- [ ] `git::is_valid_commit -C "$REPO"` resolves commit=HEAD via default, not -C.
+- [ ] Test distinguishes buggy from fixed.
+- [ ] Gate green.
+
+## Effort
+
+XS — same mechanical pattern as #314.

--- a/scripts/core/src/git.sh
+++ b/scripts/core/src/git.sh
@@ -195,8 +195,13 @@ git::current_commit_hash() {
 # Check if a given commit is a valid commit in the local repository
 #"
 git::is_valid_commit() {
-  local -r commit="${1:-HEAD}"
-  [[ -n "${1:-}" ]] && shift
+  local commit
+  if [[ -n "${1:-}" && "$1" != -* ]]; then
+    commit="$1"
+    shift
+  else
+    commit="HEAD"
+  fi
 
   [[ $(git::git "$@" cat-file -t "$commit") == commit ]]
 }

--- a/tests/core/git.bats
+++ b/tests/core/git.bats
@@ -107,6 +107,14 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
+# Distinguishing regression test: calling is_valid_commit with -C as the first
+# argument (no explicit commit) — the fixed code defaults commit=HEAD (valid),
+# the buggy code consumes -C as the commit name (invalid).
+@test "git::is_valid_commit with -C option does not consume -C" {
+    run git::is_valid_commit -C "$REPO_DIR"
+    [ "$status" -eq 0 ]
+}
+
 # ── git::add_to_gitignore ───────────────────────────────────────────────────
 # Tests use distinct files for $1 and $GITIGNORE_PATH to verify the
 # function writes to its first argument, not the global $GITIGNORE_PATH.


### PR DESCRIPTION
## fix: guard `is_valid_commit` prologue against `-C` footgun

`git::is_valid_commit` consumes `-C` as the commit argument when a caller passes `git::is_valid_commit -C "$REPO"` relying on the `HEAD` default — same footgun as #308/#314.

Applies the same `[[ "$1" != -* ]]` guard used in `check_branch_is_behind` (#313) and `check_branch_is_ahead` (#317).

**Changes:**
- `scripts/core/src/git.sh` — rewrite `is_valid_commit` prologue
- `tests/core/git.bats` — distinguishing regression test (`is_valid_commit -C "$REPO_DIR"` with no explicit commit)
- `docs/fix/319-is-valid-commit-C-option/SPEC.md` — fix spec

**Gate:** shfmt ✓, shellcheck ✓, bats 23/23 ✓

Closes #319
