### PR TITLE
fix(restorer): restore symlinks from rollback point (#296)

### DIFF
--- a/docs/fix/296-restorer-rollback-symlinks/SPEC.md
+++ b/docs/fix/296-restorer-rollback-symlinks/SPEC.md
@@ -1,0 +1,42 @@
+# fix/296-restorer-rollback-symlinks
+
+## Problem
+
+`create_rollback_point()` saves a list of symlinks from `$HOME` to
+`$ROLLBACK_DIR/symlinks.txt`, but `rollback()` only restores the dotfiles
+directory — it never reads or restores the symlinks.
+
+## Fix
+
+1. **`create_rollback_point()`**: Replace `ls -la $HOME | grep '^l'` with a
+   reliable null-delimited format using `find`:
+   ```
+   find "$HOME" -maxdepth 1 -type l -print0 | while IFS= read -r -d '' link; do
+     printf '%s\0%s\0' "$(readlink "$link")" "$link"
+   done > "$ROLLBACK_DIR/symlinks.txt"
+   ```
+   Format: `<target>\0<link_path>\0<target>\0<link_path>\0...`
+
+2. **`rollback()`**: After restoring dotfiles, parse `symlinks.txt` and
+   recreate each symlink:
+   ```bash
+   while IFS= read -r -d '' target && IFS= read -r -d '' link; do
+     rm -f "$link" 2>/dev/null
+     ln -s "$target" "$link" 2>/dev/null
+   done < "$rollback_dir/symlinks.txt"
+   ```
+
+3. **Backward compat**: If `symlinks.txt` is empty or missing, skip silently
+   (diagnostic-only mode).
+
+## Acceptance criteria
+
+- [ ] `create_rollback_point()` saves symlinks in the new null-delimited format
+- [ ] `rollback()` restores symlinks from `symlinks.txt`
+- [ ] Empty/missing `symlinks.txt` does not break rollback
+- [ ] Shellcheck + shfmt clean
+- [ ] No tests broken
+
+## Branch
+
+`fix/296-restorer-rollback-symlinks`

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| _(none)_ | | | | |
+| `296-restorer-rollback-symlinks` | restorer rollback saves symlinks but doesn't restore them | pending | — | #296 |
 
 ## Conventions
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -14,7 +14,7 @@ history lives in git log + closed issues.
 
 | Folder | Topic | Status | Depends on | Issue |
 |--------|-------|--------|------------|-------|
-| `296-restorer-rollback-symlinks` | restorer rollback saves symlinks but doesn't restore them | pending | — | #296 |
+| `296-restorer-rollback-symlinks` | restorer rollback saves symlinks but doesn't restore them | done · [#323](https://github.com/gtrabanco/dotSloth/pull/323) | — | #296 |
 
 ## Conventions
 

--- a/restorer
+++ b/restorer
@@ -125,7 +125,10 @@ create_rollback_point() {
   if [[ -d "${DOTFILES_PATH:-}" ]]; then
     cp -a "$DOTFILES_PATH" "$ROLLBACK_DIR/dotfiles" 2> /dev/null || true
   fi
-  ls -la "$HOME" 2> /dev/null | grep '^l' > "$ROLLBACK_DIR/symlinks.txt" 2> /dev/null || true
+  # Save symlinks as null-delimited pairs: <target>\0<link_path>\0
+  while IFS= read -r -d '' _link_path; do
+    printf '%s\0%s\0' "$(readlink "$_link_path")" "$_link_path"
+  done < <(find "$HOME" -maxdepth 1 -type l -print0 2> /dev/null) > "$ROLLBACK_DIR/symlinks.txt" 2> /dev/null || true
   _a "Rollback point created at $ROLLBACK_DIR"
 }
 
@@ -136,6 +139,14 @@ rollback() {
   if [[ -d "$rollback_dir/dotfiles" ]] && [[ -n "${DOTFILES_PATH:-}" ]]; then
     rm -rf "$DOTFILES_PATH"
     mv "$rollback_dir/dotfiles" "$DOTFILES_PATH"
+  fi
+  # Restore symlinks from the saved list (null-delimited pairs)
+  if [[ -s "$rollback_dir/symlinks.txt" ]]; then
+    while IFS= read -r -d '' _target && IFS= read -r -d '' _link; do
+      [[ -z "$_target" || -z "$_link" ]] && continue
+      rm -f "$_link" 2> /dev/null || true
+      ln -s "$_target" "$_link" 2> /dev/null || true
+    done < "$rollback_dir/symlinks.txt"
   fi
   _e "Rolled back to pre-restore state."
 }


### PR DESCRIPTION
## fix(restorer): restore symlinks from rollback point

`create_rollback_point()` saved symlinks to `symlinks.txt` but `rollback()` never read them — symlink changes persisted after a failed restore.

**Changes:**
- `create_rollback_point()` now uses `find` + `readlink` with null-delimited pairs (reliable, portable format) instead of `ls -la`
- `rollback()` now parses `symlinks.txt` and recreates each symlink during rollback
- Empty/missing `symlinks.txt` is handled gracefully (backward compat)

Closes #296
